### PR TITLE
#101: Refactor tests to use new createWrapper

### DIFF
--- a/app/tests/unit/pages/nanomine/howto.spec.js
+++ b/app/tests/unit/pages/nanomine/howto.spec.js
@@ -17,7 +17,7 @@ global.console = {
 
 describe('HowTo.vue', () => {
   beforeAll(async () => {
-    wrapper = createWrapper(HowTo, { props: {}, slots: {} })
+    wrapper = createWrapper(HowTo, {})
     await wrapper.vm.$nextTick()
   })
 

--- a/app/tests/unit/pages/nanomine/howto.spec.js
+++ b/app/tests/unit/pages/nanomine/howto.spec.js
@@ -1,35 +1,35 @@
-import { mount, createLocalVue } from '@vue/test-utils'
-import Vuex from 'vuex'
-
+import createWrapper from '../../../jest/script/wrapper'
 import HowTo from '@/pages/nanomine/howTo/HowTo.vue'
-import store from '@/store'
 
-const localVue = createLocalVue()
-localVue.use(Vuex)
+var wrapper = null
+// suppress jsdom alert 'Not implemented window.open'
+window.open = jest.fn()
+window.open.mockClear()
+global.console = {
+  log: jest.fn(), // console.log are ignored in tests
 
-beforeAll(() => {
-  jest.resetModules()
-})
+  // Keep native behavior for other methods
+  error: console.error,
+  warn: console.warn,
+  info: console.info,
+  debug: console.debug
+}
 
 describe('HowTo.vue', () => {
+  beforeAll(async () => {
+    wrapper = createWrapper(HowTo, { props: {}, slots: {} })
+    await wrapper.vm.$nextTick()
+  })
+
   it('mounts properly', () => {
-    const wrapper = mount(HowTo, { store, localVue })
     expect(wrapper.exists()).toBeTruthy()
   })
 
   it('hides all videos to start', () => {
-    const wrapper = mount(HowTo, { store, localVue })
     expect(wrapper.find('#videoPlayerContainer').exists()).toBeFalsy()
   })
 
   it('displays video on first click, hides it on second click', async () => {
-    // suppress jsdom alert 'Not implemented window.open'
-    window.open = jest.fn()
-    window.open.mockClear()
-
-    const wrapper = mount(HowTo, { store, localVue })
-    await localVue.nextTick() // wait for videos to load
-
     const videoTitle = wrapper.find('.howto_item .howto_item-header')
     expect(videoTitle.exists()).toBeTruthy()
 
@@ -41,13 +41,6 @@ describe('HowTo.vue', () => {
   })
 
   it('closes any other open videos when a new one is clicked', async () => {
-    // suppress jsdom alert 'Not implemented window.open'
-    window.open = jest.fn()
-    window.open.mockClear()
-
-    const wrapper = mount(HowTo, { store, localVue })
-    await localVue.nextTick() // wait for videos to load
-
     const videoTitle = wrapper.findAll('.howto_item .howto_item-header')
 
     await videoTitle.at(0).trigger('click')
@@ -58,13 +51,6 @@ describe('HowTo.vue', () => {
   })
 
   it('correctly opens a link if passed one', async () => {
-    // suppress jsdom alert 'Not implemented window.open'
-    window.open = jest.fn()
-    window.open.mockClear()
-
-    const wrapper = mount(HowTo, { store, localVue })
-    await localVue.nextTick() // wait for videos to load
-
     const videoIcons = wrapper.findAll('.material-icons')
 
     if (videoIcons.exists()) {

--- a/app/tests/unit/pages/nanomine/news.spec.js
+++ b/app/tests/unit/pages/nanomine/news.spec.js
@@ -1,32 +1,23 @@
-import { mount, createLocalVue } from '@vue/test-utils'
-import Vuex from 'vuex'
+import createWrapper from '../../../jest/script/wrapper'
 import News from '@/pages/nanomine/researchnews/News.vue'
-import store from '@/store'
 
-const localVue = createLocalVue()
-localVue.use(Vuex)
+var wrapper = null
 
 describe('News.vue', () => {
+  beforeAll(() => {
+    wrapper = createWrapper(News, { props: {}, slots: {} })
+  })
   it('mounts properly', () => {
-    const wrapper = mount(News, { store, localVue })
     expect(wrapper.exists()).toBeTruthy()
   })
 
   it('loads research', () => {
-    const wrapper = mount(News, { store, localVue })
     const research = wrapper.findAll('.research')
     expect(research.length).toBeGreaterThanOrEqual(1)
   })
 
   it('loads news', () => {
-    const wrapper = mount(News, { store, localVue })
     const news = wrapper.findAll('.news-container')
     expect(news.length).toBeGreaterThanOrEqual(1)
   })
-
-  // it('loads partners', () => {
-  //   const wrapper = mount(News, { store, localVue })
-  //   const partner_container = wrapper.get('.team_partner-container')
-  //   expect(partner_container.findAll('.teams_partner').length).toBeGreaterThanOrEqual(4)
-  // })
 })

--- a/app/tests/unit/pages/nanomine/news.spec.js
+++ b/app/tests/unit/pages/nanomine/news.spec.js
@@ -5,7 +5,7 @@ var wrapper = null
 
 describe('News.vue', () => {
   beforeAll(() => {
-    wrapper = createWrapper(News, { props: {}, slots: {} })
+    wrapper = createWrapper(News, {})
   })
   it('mounts properly', () => {
     expect(wrapper.exists()).toBeTruthy()

--- a/app/tests/unit/pages/nanomine/teams.spec.js
+++ b/app/tests/unit/pages/nanomine/teams.spec.js
@@ -1,25 +1,23 @@
-import { mount, createLocalVue } from '@vue/test-utils'
-import Vuex from 'vuex'
+import createWrapper from '../../../jest/script/wrapper'
 import TeamsPage from '@/pages/nanomine/teams/Teams.vue'
-import store from '@/store'
 
-const localVue = createLocalVue()
-localVue.use(Vuex)
+var wrapper = null
 
 describe('Teams.vue', () => {
+  beforeAll(() => {
+    wrapper = createWrapper(TeamsPage, { props: {}, slots: {} })
+  })
+
   it('mounts properly', () => {
-    const wrapper = mount(TeamsPage, { store, localVue })
     expect(wrapper.exists()).toBeTruthy()
   })
 
   it('loads team members', () => {
-    const wrapper = mount(TeamsPage, { store, localVue })
     const teamsList = wrapper.get('.teams_list').get('ul')
     expect(teamsList.findAll('.teams_container').length).toBeGreaterThanOrEqual(6)
   })
 
   it('loads partners', () => {
-    const wrapper = mount(TeamsPage, { store, localVue })
     const partnerContainer = wrapper.get('.team_partner-container')
     expect(partnerContainer.findAll('.teams_partner').length).toBeGreaterThanOrEqual(4)
   })

--- a/app/tests/unit/pages/nanomine/teams.spec.js
+++ b/app/tests/unit/pages/nanomine/teams.spec.js
@@ -5,7 +5,7 @@ var wrapper = null
 
 describe('Teams.vue', () => {
   beforeAll(() => {
-    wrapper = createWrapper(TeamsPage, { props: {}, slots: {} })
+    wrapper = createWrapper(TeamsPage, {})
   })
 
   it('mounts properly', () => {


### PR DESCRIPTION
fix(#101): Refactor tests to use new createWrapper

Refactored tests to remove repeated setup code and use new consistent
`createWrapper`. Also suppressed `console.log` calls in howto tests