### PR TITLE
#104: Add styling to dialog boxes

### DIFF
--- a/app/src/assets/css/abstract/_variables.scss
+++ b/app/src/assets/css/abstract/_variables.scss
@@ -7,6 +7,7 @@
 $primary: #08233c;
 $primary-light: #083d56;
 $secondary: #0e5f76;
+$secondary-mid: #64b5f6;
 $secondary-light: #afe3f1;
 $tertiary: #d7df71;
 $primary-white: #ffffff;

--- a/app/src/assets/css/modules/_utility.scss
+++ b/app/src/assets/css/modules/_utility.scss
@@ -168,3 +168,22 @@
     }
 
 }
+
+.dialog-box {
+    .md-dialog-container{
+        overflow: scroll !important;
+    }
+    &_header {
+        background-color: $secondary-mid !important;
+        padding: 1rem 1.5rem !important;
+
+        & > span {
+            padding: 0rem !important;
+        }
+    }
+    &_actions {
+        .md-button-content{
+            color: $secondary-mid !important
+        }
+    }
+}

--- a/app/src/components/Dialog.vue
+++ b/app/src/components/Dialog.vue
@@ -1,9 +1,26 @@
 <template>
   <div>
-    <md-dialog
+    <md-dialog class="dialog-box"
       :md-active.sync="active"
       :md-click-outside-to-close="false">
-      <slot></slot>
+      <div class="dialog-box_header">
+        <md-dialog-title>
+          <slot name="title">
+          </slot>
+        </md-dialog-title>
+      </div>
+      <div class="dialog-box_content">
+        <md-dialog-content>
+          <slot name="content">
+          </slot>
+        </md-dialog-content>
+      </div>
+      <div class="dialog-box_actions">
+        <md-dialog-actions>
+          <slot name="actions">
+          </slot>
+        </md-dialog-actions>
+      </div>
       </md-dialog>
   </div>
 </template>

--- a/app/tests/unit/components/dialog.spec.js
+++ b/app/tests/unit/components/dialog.spec.js
@@ -5,7 +5,9 @@ import Dialog from '@/components/Dialog.vue'
 describe('@/components/Dialog.vue', () => {
   let wrapper
   const slots = {
-    default: ['<p>Testing</p>']
+    title: ['<header>Test Title</header>'],
+    content: ['<p>Testing</p>'],
+    actions: ['<button>Test Close</button>']
   }
   beforeEach(() => {
     wrapper = createWrapper(Dialog, { slots }, false)
@@ -27,10 +29,24 @@ describe('@/components/Dialog.vue', () => {
     expect(wrapper.props('active')).toBe(testProps.active)
   })
 
-  it('contains slot', () => {
+  it('contains content slot', () => {
     expect.assertions(2)
     const slotExist = wrapper.find('p')
     expect(slotExist.exists()).toBe(true)
     expect(slotExist.text()).toBe('Testing')
+  })
+
+  it('contains title slot', () => {
+    expect.assertions(2)
+    const slotExist = wrapper.find('header')
+    expect(slotExist.exists()).toBe(true)
+    expect(slotExist.text()).toBe('Test Title')
+  })
+
+  it('contains actions slot', () => {
+    expect.assertions(2)
+    const slotExist = wrapper.find('button')
+    expect(slotExist.exists()).toBe(true)
+    expect(slotExist.text()).toBe('Test Close')
   })
 })


### PR DESCRIPTION
 Migrated dialog box styling from whyis
Added named slots for title, content, and actions (e.g., button to close) to facilitate standardized styling
Updated tests in `dialog.spec.js`

close #104 