### PR TITLE
feat(#85): Create logger service - restful

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,6 @@ package-lock.json
 # Local DBs
 **/**/db
 
+# Rest
+**/**/*.log
 

--- a/resfulservice/package.json
+++ b/resfulservice/package.json
@@ -24,7 +24,8 @@
         "multer": "^1.4.4",
         "node-schedule": "^2.1.0",
         "nodemailer": "^6.7.2",
-        "swagger-ui-express": "^4.2.0"
+        "swagger-ui-express": "^4.2.0",
+        "winston": "^3.5.1"
     },
     "scripts": {
         "start": "nodemon src/server.js",

--- a/resfulservice/src/middlewares/globalMiddleware.js
+++ b/resfulservice/src/middlewares/globalMiddleware.js
@@ -1,0 +1,34 @@
+const bodyParser = require('body-parser');
+const acceptedHeaders = require('./accept');
+const getEnv = require('./parseEnv');
+const { fileMgr, fileServer } = require('./fileStorage');
+const mmGraphQL = require('../graphql');
+const { logParser, mmLogger } = require('./loggerService');
+
+const log = mmLogger();
+
+/**
+ * globalMiddleWare - this function that instantiate all 
+ * global middleware services for the REST API
+ * @param {*} app Express app object
+ */
+const globalMiddleWare = (app) => {
+    app.use(bodyParser.json());
+    app.use(fileMgr);
+    app.use('/mm_fils', fileServer);
+    app.use(acceptedHeaders);
+    app.use('/graphql', mmGraphQL);
+    app.use(getEnv);
+    app.use(
+        (req, res, next) => logParser(log, req, next)
+    );
+};
+
+/**
+ * This file imports all GLOBAL middleware services &
+ * exports them to the server.js file.
+ */
+module.exports = {
+    log,
+    globalMiddleWare
+};

--- a/resfulservice/src/middlewares/globalMiddleware.js
+++ b/resfulservice/src/middlewares/globalMiddleware.js
@@ -8,20 +8,20 @@ const { logParser, mmLogger } = require('./loggerService');
 const log = mmLogger();
 
 /**
- * globalMiddleWare - this function that instantiate all 
+ * globalMiddleWare - this function that instantiate all
  * global middleware services for the REST API
  * @param {*} app Express app object
  */
 const globalMiddleWare = (app) => {
-    app.use(bodyParser.json());
-    app.use(fileMgr);
-    app.use('/mm_fils', fileServer);
-    app.use(acceptedHeaders);
-    app.use('/graphql', mmGraphQL);
-    app.use(getEnv);
-    app.use(
-        (req, res, next) => logParser(log, req, next)
-    );
+  app.use(bodyParser.json());
+  app.use(fileMgr);
+  app.use('/mm_fils', fileServer);
+  app.use(acceptedHeaders);
+  app.use('/graphql', mmGraphQL);
+  app.use(getEnv);
+  app.use(
+    (req, res, next) => logParser(log, req, next)
+  );
 };
 
 /**
@@ -29,6 +29,6 @@ const globalMiddleWare = (app) => {
  * exports them to the server.js file.
  */
 module.exports = {
-    log,
-    globalMiddleWare
+  log,
+  globalMiddleWare
 };

--- a/resfulservice/src/middlewares/loggerService.js
+++ b/resfulservice/src/middlewares/loggerService.js
@@ -1,0 +1,46 @@
+const { createLogger, format, transports } = require('winston');
+const { combine, timestamp, label, printf, prettyPrint } = format;
+const env = process.env;
+
+const logFormat = printf(({ level, message, label, timestamp }) => {
+  return `${timestamp} [${label}] ${level}: ${message}`;
+});
+
+const transport = {
+  file: new (transports.File)({
+    filename: env?.logfile || 'rest_api.log',
+    level: 'debug',
+    maxfiles: 10,
+    maxsize: 52428800
+  })
+};
+
+exports.mmLogger = () => {
+  const logger = createLogger({
+    levels: {
+      emerg: 0,
+      alert: 1,
+      crit: 2,
+      error: 3,
+      warning: 4,
+      notice: 5,
+      info: 6,
+      debug: 7
+    },
+    format: combine(
+      label({ label: 'rest-api' }),
+      timestamp(),
+      prettyPrint(),
+      logFormat
+    ),
+    transports: [
+      transport.file
+    ]
+  });
+  return logger;
+};
+
+exports.logParser = (logger, req, next) => {
+  req.logger = logger;
+  next();
+};

--- a/resfulservice/src/server.js
+++ b/resfulservice/src/server.js
@@ -1,21 +1,10 @@
 const express = require('express');
 const mongoose = require('mongoose');
-const bodyParser = require('body-parser');
-const acceptedHeaders = require('./middlewares/accept');
-const getEnv = require('./middlewares/parseEnv');
-const { fileMgr, fileServer } = require('./middlewares/fileStorage');
-const mmGraphQL = require('./graphql');
-// const testRoutes = require('./routes/test');
+const { globalMiddleWare, log } = require('./middlewares/globalMiddleware');
 const env = process.env;
 
 const app = express();
-
-app.use(bodyParser.json());
-app.use(fileMgr);
-app.use('/mm_fils', fileServer);
-app.use(acceptedHeaders);
-app.use('/graphql', mmGraphQL);
-app.use(getEnv);
+globalMiddleWare(app);
 
 app.use((error, req, res, next) => {
   console.log(error);
@@ -29,5 +18,8 @@ mongoose
   .connect(`mongodb://${env.DB_USERNAME}:${env.DB_PASSWORD}@${env.MONGO_ADDRESS}:${env.MONGO_PORT}/${env.MM_DB}`, {
     useNewUrlParser: true, useUnifiedTopology: true
   })
-  .then(app.listen(process.env.PORT || 3000))
+  .then(() => {
+    log.info('Rest server starting up...');
+    app.listen(process.env.PORT || 3000);
+  })
   .catch(err => console.log(err));


### PR DESCRIPTION
- All middleware services that are needed globally are now moved into src/middleware/globalMiddleware.js file and then imported into server.js file
- Remove all middlewares from server.js
- Added a global logger service. The new logger is appended to the request header automatically and can be retrieved from any route or module.
- Added Winston to package.json and removed gitignored log files.

close #85 