### PR TITLE
#123 Refactor sparql.js

### DIFF
--- a/app/src/modules/sparql.js
+++ b/app/src/modules/sparql.js
@@ -1,3 +1,6 @@
+import { literal, namedNode } from '@rdfjs/data-model'
+import { fromRdf } from 'rdf-literal'
+
 const SPARQL_ENDPOINT = 'https://materialsmine.org/wi/sparql'
 
 async function querySparql (query, endpoint = SPARQL_ENDPOINT) {
@@ -19,21 +22,19 @@ async function querySparql (query, endpoint = SPARQL_ENDPOINT) {
 
 function parseSparql (response) {
   const queryResults = []
-  for (let i = 0; i < response.results.bindings.length; i++) {
-    const newObject = {}
-    const row = response.results.bindings[i]
-    for (const variable of response.head.vars) {
-      if (row !== undefined && row[variable] !== undefined && row[variable]) {
-        if (!isNaN(row[variable].value)) {
-          newObject[variable] = +row[variable].value
-        } else {
-          newObject[variable] = row[variable].value
+  if (response) {
+    for (const row of response.results.bindings) {
+      const rowData = {}
+      queryResults.push(rowData)
+      Object.entries(row).forEach(([field, result, t]) => {
+        let value = result.value
+        if (result.type === 'literal' && result.datatype) {
+          value = fromRdf(literal(value, namedNode(result.datatype)))
         }
-        queryResults[i] = newObject
-      }
+        rowData[field] = value
+      })
     }
   }
-
   return queryResults
 }
 

--- a/app/src/modules/sparql.js
+++ b/app/src/modules/sparql.js
@@ -17,9 +17,7 @@ async function querySparql (query, endpoint = SPARQL_ENDPOINT) {
     .catch((err) => console.log(err))
 }
 
-export { querySparql }
-
-export function parseSPARQL (response) {
+function parseSPARQL (response) {
   const queryResults = []
   for (let i = 0; i < response.results.bindings.length; i++) {
     const newObject = {}
@@ -38,3 +36,5 @@ export function parseSPARQL (response) {
 
   return queryResults
 }
+
+export { querySparql, parseSPARQL }

--- a/app/src/modules/sparql.js
+++ b/app/src/modules/sparql.js
@@ -17,7 +17,7 @@ async function querySparql (query, endpoint = SPARQL_ENDPOINT) {
     .catch((err) => console.log(err))
 }
 
-function parseSPARQL (response) {
+function parseSparql (response) {
   const queryResults = []
   for (let i = 0; i < response.results.bindings.length; i++) {
     const newObject = {}
@@ -37,4 +37,4 @@ function parseSPARQL (response) {
   return queryResults
 }
 
-export { querySparql, parseSPARQL }
+export { querySparql, parseSparql }

--- a/app/src/modules/vega-chart.js
+++ b/app/src/modules/vega-chart.js
@@ -1,6 +1,4 @@
-import { literal, namedNode } from '@rdfjs/data-model'
-import { fromRdf } from 'rdf-literal'
-import { querySparql } from '@/modules/sparql'
+import { querySparql, parseSparql } from '@/modules/sparql'
 
 const defaultQuery = `
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
@@ -86,30 +84,12 @@ async function readChartSparqlRow (chartResult) {
   return chart
 }
 
-function transformSparqlData (sparqlResults) {
-  const data = []
-  if (sparqlResults) {
-    for (const row of sparqlResults.results.bindings) {
-      const resultData = {}
-      data.push(resultData)
-      Object.entries(row).forEach(([field, result, t]) => {
-        let value = result.value
-        if (result.type === 'literal' && result.datatype) {
-          value = fromRdf(literal(value, namedNode(result.datatype)))
-        }
-        resultData[field] = value
-      })
-    }
-  }
-  return data
-}
-
 function buildSparqlSpec (baseSpec, sparqlResults) {
   if (!baseSpec) {
     return null
   }
   const spec = Object.assign({}, baseSpec)
-  spec.data = { values: transformSparqlData(sparqlResults) }
+  spec.data = { values: parseSparql(sparqlResults) }
   return spec
 }
 

--- a/app/src/pages/explorer/sample/sample.js
+++ b/app/src/pages/explorer/sample/sample.js
@@ -1,4 +1,4 @@
-import { querySparql, parseSPARQL } from '@/modules/sparql'
+import { querySparql, parseSparql } from '@/modules/sparql'
 import sampleQueries from '@/modules/queries/sampleQueries'
 import Spinner from '@/components/Spinner'
 
@@ -26,21 +26,21 @@ export default {
     },
     parseHeader (data) {
       if (!data) return null
-      const parsedData = parseSPARQL(data)
+      const parsedData = parseSparql(data)
       if (parsedData.length === 0) return null
       const [sampleData] = parsedData
       return sampleData
     },
     parseOtherSamples (data) {
       if (!data) return null
-      const parsedData = parseSPARQL(data)
+      const parsedData = parseSparql(data)
       if (parsedData.length === 0) return null
       const links = parsedData.map(({ sample }) => sample.split('/').pop())
       return links
     },
     parseProcessLabel (data) {
       if (!data) return null
-      const parsedData = parseSPARQL(data)
+      const parsedData = parseSparql(data)
       if (parsedData.length === 0) return null
       const [processLabelObject] = parsedData
       const { process_label: processLabel } = processLabelObject
@@ -48,7 +48,7 @@ export default {
     },
     parseMaterialData (data) {
       if (!data) return null
-      const parsedData = parseSPARQL(data)
+      const parsedData = parseSparql(data)
       if (parsedData.length === 0) return null
       const seen = new Set()
       const filteredArr = parsedData
@@ -87,7 +87,7 @@ export default {
     },
     parseCuratedProperties (data) {
       if (!data) return null
-      const parseData = parseSPARQL(data)
+      const parseData = parseSparql(data)
       if (parseData.length === 0) return null
       if (!parseData.length) return null
       const curatedProperties = parseData.map((property) => {
@@ -106,7 +106,7 @@ export default {
     },
     parseProcessingSteps (data) {
       if (!data) return null
-      const parsedData = parseSPARQL(data)
+      const parsedData = parseSparql(data)
       if (parsedData.length === 0) return null
       const steps = parsedData.map(
         ({ param_label: parameterLabel, Descr: description }) => {
@@ -117,7 +117,7 @@ export default {
     },
     parseSampleImages (data) {
       if (!data) return null
-      const parsedData = parseSPARQL(data)
+      const parsedData = parseSparql(data)
       if (parsedData.length === 0) return null
       const images = parsedData.map((item) => {
         return { src: item.image, alt: item.sample }


### PR DESCRIPTION
- Fix exports in sparql.js
- Change `parseSparql` capitalization to match `querySparql`
- Remove `transformSparqlData` from vega-chart.js since its functionality is duplicated by `parseSparql`
- Modify `parseSparql` to look more like `transformSparqlData` did (e.g., change for loop)

Close #123 