### PR TITLE
Remove myself from `CODEOWNERS`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,2 @@
 *   @tholulomo @aswallace @stouffers
-/whyis/ @jpmccu @roryschadler
+/whyis/ @jpmccu


### PR DESCRIPTION
Hope you're all doing well! Just removing myself from the `CODEOWNERS` file, so Github stops assigning me to PRs about the `/whyis/` subdirectory.