### PR TITLE
#205: Recommendation for regex fix for safari

### DIFF
--- a/app/src/pages/explorer/parameterized-query/parameterized-query-page.vue
+++ b/app/src/pages/explorer/parameterized-query/parameterized-query-page.vue
@@ -251,7 +251,7 @@ export default {
         const baseQuery = this.selectedTemplate.SPARQL
         const valuesBlock = `\n  VALUES (${varNames}) {\n    (${optVals})\n  }\n`
 
-        this.query = baseQuery.replace(/(?<=where\s*{)/i, valuesBlock)
+        this.query = baseQuery.replace(/(where\s*{)/i, '$1' + valuesBlock)
       }
     },
     async execQuery () {


### PR DESCRIPTION
fix #205 
Address the bug where the parameterized query page couldn't be opened in safari