### PR TITLE
#224: Temporarily revert to opening DV in the same tab

### DIFF
--- a/app/src/pages/explorer/parameterized-query/parameterized-query-page.vue
+++ b/app/src/pages/explorer/parameterized-query/parameterized-query-page.vue
@@ -88,7 +88,7 @@
             </md-switch>
             <div class="button-row">
               <div>
-                <router-link :to="{ name: 'NewChartDataVoyager' }" target="_blank">
+                <router-link :to="{ name: 'NewChartDataVoyager' }">
                   <button
                     class="btn btn--primary"
                     @click="selectQueryForVizEditor()"


### PR DESCRIPTION
#224 
This does not close 224 but temporarily removes opening in a new tab for the demo tomorrow. It would be great if someone else could pull the changes locally to ensure it works since my build is misbehaving