### PR TITLE
#210 Add properties to parameterized query dropdowns 

### DIFF
--- a/app/src/pages/explorer/parameterized-query/parameterized-query-page.vue
+++ b/app/src/pages/explorer/parameterized-query/parameterized-query-page.vue
@@ -266,8 +266,8 @@ export default {
         Object.keys(activeReplacements).map((varName) => {
           // convert to variable names and replace in query
           const replacement = `?${this.camelize(activeReplacements[varName])}`
-          var originalRE = new RegExp('\\?' + varName)
-          tempQuery = tempQuery.replace(originalRE, replacement)
+          var originalRE = new RegExp('\\?' + varName, 'g')
+          tempQuery = tempQuery.replaceAll(originalRE, replacement)
         })
       }
       this.query = tempQuery

--- a/app/src/pages/explorer/parameterized-query/templates/PQ01.ttl
+++ b/app/src/pages/explorer/parameterized-query/templates/PQ01.ttl
@@ -13,7 +13,7 @@ materialsmine_templates:PQ01 a whyis:SparqlTemplate;
 PREFIX sio: <http://semanticscience.org/resource/>
 PREFIX mm: <http://materialsmine.org/ns/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-SELECT DISTINCT * WHERE {
+SELECT DISTINCT ?Sample ?Filler ?FillerAmount ?Matrix ?AttributeValue ?UnitOfMeasure WHERE {
   ?Sample a mm:PolymerNanocomposite ;
           sio:hasComponentPart [ sio:hasRole [ a mm:Filler ] ;
                                  a [ rdfs:label ?Filler ] ;
@@ -21,9 +21,10 @@ SELECT DISTINCT * WHERE {
                                                     sio:hasValue ?FillerAmount] ] ,
                                [ sio:hasRole [ a mm:Matrix ] ;
                                  a [ rdfs:label ?Matrix ] ] ;
-          sio:hasAttribute [ a ?AttributeType ;
-                             sio:hasValue ?AttributeValue ;
-                             sio:hasUnit ?UnitOfMeasure ] .
+          sio:hasAttribute  ?Attr .
+  ?Attr a ?AttributeType ;
+     sio:hasValue ?AttributeValue .
+  OPTIONAL { ?Attr sio:hasUnit ?UnitOfMeasure }
 }
 """;
   spin:constraint [
@@ -314,7 +315,7 @@ SELECT DISTINCT * WHERE {
   [
     sp:varName "FillerAmount";
     mmpq:subVar "AmountType" ; 
-    mmpq:varFormat "${var}";
+    mmpq:varFormat "${var}Fraction";
   ],
   [
     sp:varName "AttributeValue";

--- a/app/src/pages/explorer/parameterized-query/templates/PQ01.ttl
+++ b/app/src/pages/explorer/parameterized-query/templates/PQ01.ttl
@@ -277,5 +277,35 @@ SELECT DISTINCT * WHERE {
         rdfs:label "surface resistivity";
         schema:identifier <http://materialsmine.org/ns/SurfaceResistivity>;
         schema:position 15
+      ],
+      [
+        rdfs:label "dielectric constant";
+        schema:identifier <http://materialsmine.org/ns/DielectricConstant>;
+        schema:position 16
+      ],
+      [
+        rdfs:label "breakdown strength";
+        schema:identifier <http://materialsmine.org/ns/BreakdownStrength>;
+        schema:position 17
+      ],
+      [
+        rdfs:label "conductivity";
+        schema:identifier <http://materialsmine.org/ns/Conductivity>;
+        schema:position 18
+      ],
+      [
+        rdfs:label "halflife of crystallization";
+        schema:identifier <http://materialsmine.org/ns/HalflifeOfCrystallization>;
+        schema:position 19
+      ],
+      [
+        rdfs:label "loss modulus";
+        schema:identifier <http://materialsmine.org/ns/LossModulus>;
+        schema:position 20
+      ],
+      [
+        rdfs:label "storage modulus";
+        schema:identifier <http://materialsmine.org/ns/StorageModulus>;
+        schema:position 21
       ]
   ].

--- a/app/src/pages/explorer/parameterized-query/templates/PQ01A.ttl
+++ b/app/src/pages/explorer/parameterized-query/templates/PQ01A.ttl
@@ -13,7 +13,7 @@ materialsmine_templates:PQ01A a whyis:SparqlTemplate;
 PREFIX sio: <http://semanticscience.org/resource/>
 PREFIX mm: <http://materialsmine.org/ns/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-SELECT DISTINCT * WHERE {
+SELECT DISTINCT ?Sample ?Filler ?FillerAmount ?Matrix ?AttributeValue1 ?UnitOfMeasure1 ?AttributeValue2 ?UnitOfMeasure2 WHERE {
   ?Sample a mm:PolymerNanocomposite ;
           sio:hasComponentPart [ sio:hasRole [ a mm:Filler ] ;
                                  a [ rdfs:label ?Filler ] ;
@@ -21,12 +21,14 @@ SELECT DISTINCT * WHERE {
                                                     sio:hasValue ?FillerAmount] ] ,
                                [ sio:hasRole [ a mm:Matrix ] ;
                                  a [ rdfs:label ?Matrix ] ] ;
-          sio:hasAttribute [ a ?AttributeType1 ;
-                             sio:hasValue ?AttributeValue1 ;
-                             sio:hasUnit ?UnitOfMeasure1 ] ;
-          sio:hasAttribute [ a ?AttributeType2 ;
-                             sio:hasValue ?AttributeValue2 ;
-                             sio:hasUnit ?UnitOfMeasure2 ] .
+          sio:hasAttribute  ?Attr1 ;
+          sio:hasAttribute  ?Attr2 .
+  ?Attr1 a ?AttributeType1 ;
+      sio:hasValue ?AttributeValue1 .
+  ?Attr2 a ?AttributeType2 ;
+      sio:hasValue ?AttributeValue2 .
+  OPTIONAL { ?Attr1 sio:hasUnit ?UnitOfMeasure1 }
+  OPTIONAL { ?Attr2 sio:hasUnit ?UnitOfMeasure2 }
 }
 """;
   spin:constraint [
@@ -426,7 +428,7 @@ SELECT DISTINCT * WHERE {
   [
     sp:varName "FillerAmount";
     mmpq:subVar "AmountType" ; 
-    mmpq:varFormat "${var}";
+    mmpq:varFormat "${var}Fraction";
   ],
   [
     sp:varName "AttributeValue1";

--- a/app/src/pages/explorer/parameterized-query/templates/PQ01A.ttl
+++ b/app/src/pages/explorer/parameterized-query/templates/PQ01A.ttl
@@ -280,6 +280,36 @@ SELECT DISTINCT * WHERE {
         rdfs:label "surface resistivity";
         schema:identifier <http://materialsmine.org/ns/SurfaceResistivity>;
         schema:position 15
+      ],
+      [
+        rdfs:label "dielectric constant";
+        schema:identifier <http://materialsmine.org/ns/DielectricConstant>;
+        schema:position 16
+      ],
+      [
+        rdfs:label "breakdown strength";
+        schema:identifier <http://materialsmine.org/ns/BreakdownStrength>;
+        schema:position 17
+      ],
+      [
+        rdfs:label "conductivity";
+        schema:identifier <http://materialsmine.org/ns/Conductivity>;
+        schema:position 18
+      ],
+      [
+        rdfs:label "halflife of crystallization";
+        schema:identifier <http://materialsmine.org/ns/HalflifeOfCrystallization>;
+        schema:position 19
+      ],
+      [
+        rdfs:label "loss modulus";
+        schema:identifier <http://materialsmine.org/ns/LossModulus>;
+        schema:position 20
+      ],
+      [
+        rdfs:label "storage modulus";
+        schema:identifier <http://materialsmine.org/ns/StorageModulus>;
+        schema:position 21
       ]
   ],
   [
@@ -359,5 +389,35 @@ SELECT DISTINCT * WHERE {
         rdfs:label "surface resistivity";
         schema:identifier <http://materialsmine.org/ns/SurfaceResistivity>;
         schema:position 15
+      ],
+      [
+        rdfs:label "dielectric constant";
+        schema:identifier <http://materialsmine.org/ns/DielectricConstant>;
+        schema:position 16
+      ],
+      [
+        rdfs:label "breakdown strength";
+        schema:identifier <http://materialsmine.org/ns/BreakdownStrength>;
+        schema:position 17
+      ],
+      [
+        rdfs:label "conductivity";
+        schema:identifier <http://materialsmine.org/ns/Conductivity>;
+        schema:position 18
+      ],
+      [
+        rdfs:label "halflife of crystallization";
+        schema:identifier <http://materialsmine.org/ns/HalflifeOfCrystallization>;
+        schema:position 19
+      ],
+      [
+        rdfs:label "loss modulus";
+        schema:identifier <http://materialsmine.org/ns/LossModulus>;
+        schema:position 20
+      ],
+      [
+        rdfs:label "storage modulus";
+        schema:identifier <http://materialsmine.org/ns/StorageModulus>;
+        schema:position 21
       ]
   ].

--- a/app/src/pages/explorer/parameterized-query/templates/PQ09.ttl
+++ b/app/src/pages/explorer/parameterized-query/templates/PQ09.ttl
@@ -323,5 +323,35 @@ SELECT DISTINCT * WHERE {
         rdfs:label "surface resistivity";
         schema:identifier <http://materialsmine.org/ns/SurfaceResistivity>;
         schema:position 15
+      ],
+      [
+        rdfs:label "dielectric constant";
+        schema:identifier <http://materialsmine.org/ns/DielectricConstant>;
+        schema:position 16
+      ],
+      [
+        rdfs:label "breakdown strength";
+        schema:identifier <http://materialsmine.org/ns/BreakdownStrength>;
+        schema:position 17
+      ],
+      [
+        rdfs:label "conductivity";
+        schema:identifier <http://materialsmine.org/ns/Conductivity>;
+        schema:position 18
+      ],
+      [
+        rdfs:label "halflife of crystallization";
+        schema:identifier <http://materialsmine.org/ns/HalflifeOfCrystallization>;
+        schema:position 19
+      ],
+      [
+        rdfs:label "loss modulus";
+        schema:identifier <http://materialsmine.org/ns/LossModulus>;
+        schema:position 20
+      ],
+      [
+        rdfs:label "storage modulus";
+        schema:identifier <http://materialsmine.org/ns/StorageModulus>;
+        schema:position 21
       ]
   ].

--- a/app/src/pages/explorer/parameterized-query/templates/PQ09.ttl
+++ b/app/src/pages/explorer/parameterized-query/templates/PQ09.ttl
@@ -13,15 +13,16 @@ materialsmine_templates:PQ09 a whyis:SparqlTemplate;
 PREFIX sio: <http://semanticscience.org/resource/>
 PREFIX mm: <http://materialsmine.org/ns/>
 PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>
-SELECT DISTINCT * WHERE {
+SELECT DISTINCT ?Sample ?Filler ?Matrix ?AttributeValue ?UnitOfMeasure WHERE {
   ?Sample a mm:PolymerNanocomposite ;
           sio:hasComponentPart [ sio:hasRole [ a mm:Filler ] ;
                                  a [ rdfs:label ?Filler ] ] ,
                                [ sio:hasRole [ a mm:Matrix ] ;
                                  a [ rdfs:label ?Matrix] ] ;
-          sio:hasAttribute [ a ?AttributeType ;
-                             sio:hasValue ?AttributeValue ;
-                             sio:hasUnit [ rdfs:label ?UnitOfMeasure ] ]
+          sio:hasAttribute ?Attr .
+  ?Attr a ?AttributeType ;
+     sio:hasValue ?AttributeValue .
+  OPTIONAL { ?Attr sio:hasUnit ?UnitOfMeasure }
   FILTER((?Filler = ?Filler1) || (?Filler = ?Filler2) || (?Filler = ?Filler3))
 }
 """;

--- a/app/src/pages/explorer/parameterized-query/templates/PQ15.ttl
+++ b/app/src/pages/explorer/parameterized-query/templates/PQ15.ttl
@@ -324,5 +324,25 @@ ORDER BY DESC (?CountOfDOIs)
         rdfs:label "melting temperature";
         schema:identifier <http://materialsmine.org/ns/MeltingTemperature>;
         schema:position 9
+      ],
+      [
+        rdfs:label "dielectric constant";
+        schema:identifier <http://materialsmine.org/ns/DielectricConstant>;
+        schema:position 10
+      ],
+      [
+        rdfs:label "breakdown strength";
+        schema:identifier <http://materialsmine.org/ns/BreakdownStrength>;
+        schema:position 11
+      ],
+      [
+        rdfs:label "conductivity";
+        schema:identifier <http://materialsmine.org/ns/Conductivity>;
+        schema:position 12
+      ],
+      [
+        rdfs:label "halflife of crystallization";
+        schema:identifier <http://materialsmine.org/ns/HalflifeOfCrystallization>;
+        schema:position 13
       ]
   ].


### PR DESCRIPTION
Added requested missing properties to parameterized query dropdowns for queries 1, 1a, 9 and 15.
This required making units optional for 1, 1a and 9, since dielectric constant and others do not have reported units.
Also reduced which variables are returned by these queries instead of returning all, since adding units required breaking the attribute out of the blank node (creating a new column, which in some cases would have greatly increased the number of results reported back since each blank node was considered "distinct")

close #210

New TD ticket suggestion: Use setlr to handle extraction of breakdown strength so that those properties can also be included in the pq