### PR TITLE
Metamine visualization tool: #259 combine timeouts

### DIFF
--- a/app/src/modules/metamine/metamaterial-vegalite.js
+++ b/app/src/modules/metamine/metamaterial-vegalite.js
@@ -1,6 +1,5 @@
 const baseSpec = {
   $schema: 'https://vega.github.io/schema/vega-lite/v5.json',
-  width: 'container',
   hconcat: [
     {
       selection: {

--- a/app/src/pages/metamine/visualization/metamaterial-plot.js
+++ b/app/src/pages/metamine/visualization/metamaterial-plot.js
@@ -1,4 +1,3 @@
-import VegaLite from '@/components/explorer/VegaLiteWrapper.vue'
 import spinner from '@/components/Spinner'
 import { buildCsvSpec } from '@/modules/vega-chart'
 import embed from 'vega-embed'
@@ -8,11 +7,11 @@ import { METAMATERIAL_QUERY } from '@/modules/gql/metamaterial-gql'
 export default {
   name: 'Mockup',
   components: {
-    VegaLite,
     spinner
   },
   data: () => ({
     loading: false,
+    timeout: null,
     spec: null,
     baseSpec: baseSpec,
     error: { status: false, message: null },
@@ -64,19 +63,23 @@ export default {
       } finally {
         this.loading = false
       }
+    },
+    /**
+     * Pause to allow event to register
+     */
+    changeAxes () {
+      this.loading = true;
+      clearTimeout(this.timeout)
+      this.timeout = setTimeout(async () => await this.patchVegaSpec(), 500)
     }
   },
   watch:
     {
-      async xAxis () {
-        this.loading = true
-        // Pause to allow event to register
-        setTimeout(async () => await this.patchVegaSpec(), 100)
+      xAxis () {
+        this.changeAxes()
       },
-      async yAxis () {
-        this.loading = true
-        // Pause to allow event to register
-        setTimeout(async () => await this.patchVegaSpec(), 100)
+      yAxis () {
+        this.changeAxes()
       }
     },
   apollo: {

--- a/app/src/pages/metamine/visualization/metamaterial-plot.js
+++ b/app/src/pages/metamine/visualization/metamaterial-plot.js
@@ -68,7 +68,7 @@ export default {
      * Pause to allow event to register
      */
     changeAxes () {
-      this.loading = true;
+      this.loading = true
       clearTimeout(this.timeout)
       this.timeout = setTimeout(async () => await this.patchVegaSpec(), 500)
     }


### PR DESCRIPTION
- Combine the timeout calls into one function
- Remove the unused vega-lite component (we're using a different method to embed the chart)
- Remove `width: 'container'` from the vega spec -- doesn't actually affect width and causes a warning to be thrown

Using the same branch as the original PR 

close #259 