### PR TITLE
#275: Separate apolloClient into module

### DIFF
--- a/app/src/main.js
+++ b/app/src/main.js
@@ -1,5 +1,4 @@
 import Vue from 'vue'
-import ApolloClient from 'apollo-boost'
 import VueApollo from 'vue-apollo'
 import VueMaterial from 'vue-material'
 import 'vue-material/dist/vue-material.min.css'
@@ -8,17 +7,10 @@ import App from './App.vue'
 import './registerServiceWorker'
 import store from './store'
 import router from './router'
+import apollo from './modules/gql/apolloClient'
 
 const BASE = window.location.origin
 const uri = `${BASE}/api/graphql`
-
-const apolloClient = new ApolloClient({
-  uri
-})
-
-const apolloProvider = new VueApollo({
-  defaultClient: apolloClient
-})
 
 Vue.use(VueApollo)
 Vue.use(VueMaterial)
@@ -27,6 +19,6 @@ Vue.config.productionTip = false
 new Vue({
   store,
   router,
-  apolloProvider,
+  apolloProvider: apollo(uri),
   render: h => h(App)
 }).$mount('#app')

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -9,10 +9,6 @@ import store from './store'
 import router from './router'
 import apollo from './modules/gql/apolloClient'
 
-// Temporarily commenting out for linting/testing purposes
-// const BASE = window.location.origin
-// const uri = `${BASE}/api/graphql`
-
 const apolloProvider = new VueApollo({
   defaultClient: apollo
 })

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -13,13 +13,13 @@ import apollo from './modules/gql/apolloClient'
 // const BASE = window.location.origin
 // const uri = `${BASE}/api/graphql`
 
-Vue.use(VueApollo)
-Vue.use(VueMaterial)
-Vue.config.productionTip = false
-
 const apolloProvider = new VueApollo({
   defaultClient: apollo
 })
+
+Vue.use(VueApollo)
+Vue.use(VueMaterial)
+Vue.config.productionTip = false
 
 new Vue({
   store,

--- a/app/src/main.js
+++ b/app/src/main.js
@@ -9,16 +9,21 @@ import store from './store'
 import router from './router'
 import apollo from './modules/gql/apolloClient'
 
-const BASE = window.location.origin
-const uri = `${BASE}/api/graphql`
+// Temporarily commenting out for linting/testing purposes
+// const BASE = window.location.origin
+// const uri = `${BASE}/api/graphql`
 
 Vue.use(VueApollo)
 Vue.use(VueMaterial)
 Vue.config.productionTip = false
 
+const apolloProvider = new VueApollo({
+  defaultClient: apollo
+})
+
 new Vue({
   store,
   router,
-  apolloProvider: apollo(uri),
+  apolloProvider,
   render: h => h(App)
 }).$mount('#app')

--- a/app/src/modules/gql/apolloClient.js
+++ b/app/src/modules/gql/apolloClient.js
@@ -1,0 +1,26 @@
+import { ApolloClient, ApolloLink, InMemoryCache, HttpLink } from 'apollo-boost'
+import VueApollo from 'vue-apollo'
+
+export default (uri) => {
+  const httpLink = new HttpLink({ uri })
+  const authLink = new ApolloLink((operation, forward) => {
+    // add the authorization to the headers
+    const token = localStorage.getItem('token') || null
+    operation.setContext({
+      headers: {
+        authorization: token ? `${token}` : ''
+      }
+    })
+    return forward(operation)
+  })
+
+  const apolloClient = new ApolloClient({
+    uri,
+    link: authLink.concat(httpLink), // Chain auth token with the HttpLink
+    cache: new InMemoryCache()
+  })
+
+  return new VueApollo({
+    defaultClient: apolloClient
+  })
+}

--- a/app/src/modules/gql/apolloClient.js
+++ b/app/src/modules/gql/apolloClient.js
@@ -1,26 +1,23 @@
 import { ApolloClient, ApolloLink, InMemoryCache, HttpLink } from 'apollo-boost'
-import VueApollo from 'vue-apollo'
 
-export default (uri) => {
-  const httpLink = new HttpLink({ uri })
-  const authLink = new ApolloLink((operation, forward) => {
-    // add the authorization to the headers
-    const token = localStorage.getItem('token') || null
-    operation.setContext({
-      headers: {
-        authorization: token ? `${token}` : ''
-      }
-    })
-    return forward(operation)
+// NOTE: Putting BASE and uri here instead of in main still works,
+// and removes need for passing as variable
+const BASE = window.location.origin
+const uri = `${BASE}/api/graphql`
+const httpLink = new HttpLink({ uri })
+const authLink = new ApolloLink((operation, forward) => {
+  // add the authorization to the headers
+  const token = localStorage.getItem('token') || null
+  operation.setContext({
+    headers: {
+      authorization: token ? `${token}` : ''
+    }
   })
+  return forward(operation)
+})
 
-  const apolloClient = new ApolloClient({
-    uri,
-    link: authLink.concat(httpLink), // Chain auth token with the HttpLink
-    cache: new InMemoryCache()
-  })
-
-  return new VueApollo({
-    defaultClient: apolloClient
-  })
-}
+export default new ApolloClient({
+  uri: uri,
+  link: authLink.concat(httpLink), // Chain auth token with the HttpLink
+  cache: new InMemoryCache()
+})

--- a/app/src/modules/gql/apolloClient.js
+++ b/app/src/modules/gql/apolloClient.js
@@ -1,7 +1,5 @@
 import { ApolloClient, ApolloLink, InMemoryCache, HttpLink } from 'apollo-boost'
 
-// NOTE: Putting BASE and uri here instead of in main still works,
-// and removes need for passing as variable
 const BASE = window.location.origin
 const uri = `${BASE}/api/graphql`
 const httpLink = new HttpLink({ uri })


### PR DESCRIPTION
Separate apolloClient into its own module. Current version works with Vuex actions, but still requires cache and link (error below)
Note that omitting link and cache from `new ApolloClient` results in the following error: 
```
In order to initialize Apollo Client, you must specify 'link' and 'cache' properties in the options object.
These options are part of the upgrade requirements when migrating from Apollo Client 1.x to Apollo Client 2.x.
For more information, please visit: https://www.apollographql.com/docs/tutorial/client.html#apollo-client-setup
```

close #275 