### PR TITLE
#224: Update datavoyager link to use button

### DIFF
--- a/app/src/pages/explorer/parameterized-query/parameterized-query-page.vue
+++ b/app/src/pages/explorer/parameterized-query/parameterized-query-page.vue
@@ -89,14 +89,12 @@
             </md-switch>
             <div class="button-row">
               <div>
-                <router-link :to="{ name: 'NewChartDataVoyager' }">
-                  <button
+                <button
                     class="btn btn--primary"
                     @click="selectQueryForVizEditor()"
                   >
                     Open in Datavoyager
-                  </button>
-                </router-link>
+                </button>
               </div>
             </div>
           </div>
@@ -179,6 +177,7 @@ export default {
     ...mapMutations('vega', ['setQuery']),
     selectQueryForVizEditor () {
       this.setQuery(this.query)
+      this.$router.push({ name: 'NewChartDataVoyager' })
     },
     async loadSparqlTemplates () {
       this.loadingTemplates = true


### PR DESCRIPTION
Fixed the issue where Data Voyager is opened in a new tab (e.g., when the button in the parameterized query UI is clicked), and the data does not get passed correctly and instead only provides the default query data.

closes #224 