### PR TITLE
fix(ci/cd): #309 Re-enabled Whyis image build only after pull req…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,7 +76,7 @@ jobs:
       DOCKERHUB_USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
       DOCKERHUB_TOKEN: ${{ secrets.DOCKERHUB_TOKEN }}
   BuildWhyis:
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'push'
     uses: Duke-MatSci/materialsmine/.github/workflows/builder.yml@develop
     with:
       myid: kgapp


### PR DESCRIPTION
Re-enabled WHYIS image build only after pull request approval