### PR TITLE
Fix(chore): Kg instance limit hotfix

### DIFF
--- a/docker-compose.test.git.yml
+++ b/docker-compose.test.git.yml
@@ -14,7 +14,7 @@ services:
     volumes:
       - ./mockDB/mongo-init.sh:/docker-entrypoint-initdb.d/mongo-init.sh
   api:
-    image: 'dukematsci/prod/dev-restful:latest'
+    image: 'dukematsci/prod-restful:latest'
     depends_on:
       - mongo
     environment:
@@ -26,11 +26,11 @@ services:
       - TKNS=${TKNS}
       - MM_RUNTIME_ENV=${MM_RUNTIME_ENV}
   client:
-    image: 'dukematsci/prod/dev-app:latest'
+    image: 'dukematsci/prod-app:latest'
     depends_on:
       - api
   kgapp:
-    image: 'dukematsci/prod/dev-kgapp:latest'
+    image: 'dukematsci/prod-kgapp:latest'
 
 volumes:
   mockDB:

--- a/resfulservice/src/controllers/adminController.js
+++ b/resfulservice/src/controllers/adminController.js
@@ -52,7 +52,12 @@ const _loadBulkElasticSearch = async (req, res, next) => {
 
     // Delete existing docs in this index type
     log.info(`_loadBulkElasticSearch(): Deleting existing ${type} indices`);
-    if (total) await elasticSearch.deleteIndexDocs(type);
+
+    /** Users will always pass limit & offset, if submitting multi bulk entries.
+     * If it's missing in request header delete existing docs
+     * Only clear if it is a one time bulk entry.
+    */
+    if ((!req.query.limit || req.query.offset === 0) && total) await elasticSearch.deleteIndexDocs(type);
     log.info(`_loadBulkElasticSearch(): Successfully deleted ${type} indices`);
 
     for (const item of data) {

--- a/resfulservice/src/controllers/adminController.js
+++ b/resfulservice/src/controllers/adminController.js
@@ -47,7 +47,7 @@ const _loadBulkElasticSearch = async (req, res, next) => {
   }
 
   try {
-    const total = data.length;
+    const total = data.length ?? 0;
     let rejected = 0;
 
     // Delete existing docs in this index type
@@ -57,8 +57,12 @@ const _loadBulkElasticSearch = async (req, res, next) => {
      * If it's missing in request header delete existing docs
      * Only clear if it is a one time bulk entry.
     */
-    if ((!req.query.limit || req.query.offset === 0) && total) await elasticSearch.deleteIndexDocs(type);
-    log.info(`_loadBulkElasticSearch(): Successfully deleted ${type} indices`);
+    if ((!req.query.offset || +req.query.offset === 0) && !!total) {
+      await elasticSearch.deleteIndexDocs(type);
+      log.info(`_loadBulkElasticSearch(): Successfully deleted ${type} indices`);
+    } else {
+      log.info(`_loadBulkElasticSearch(): Skipped deleting ${type} indexes`);
+    }
 
     for (const item of data) {
       const response = await elasticSearch.indexDocument(req, type, item);

--- a/resfulservice/src/controllers/kgWrapperController.js
+++ b/resfulservice/src/controllers/kgWrapperController.js
@@ -21,17 +21,21 @@ const _outboundRequest = async (req, next) => {
   let url = query?.uri;
   let altMethod;
 
-  if (!url) {
-    url = `${req.env.KNOWLEDGE_ADDRESS}/${constant[type]}`;
-    altMethod = 'get';
-  }
-
   if (!query?.uri && !type) {
     return next(errorWriter(req, 'Category type is missing', '_outboundRequest', 422));
   }
 
   if (!url) {
-    return next(errorWriter(req, 'URI is missing in the request body', '_outboundRequest', 422));
+    url = `${req.env.KNOWLEDGE_ADDRESS}/${constant[type]}`;
+    altMethod = 'get';
+  }
+
+  if (query?.type && query.limit) {
+    url = `${url}&limit=${query.limit}`;
+  }
+
+  if (query?.type && query.offset) {
+    url = `${url}&offset=${query.offset}`;
   }
 
   const preparedRequest = {


### PR DESCRIPTION
This fixes bulk import issues. WHYIS currently has a limit on response. This fix ensures we can get all data for caching for a given instance.