### PR TITLE
fix(#366): Refactor inefficient sample queries

### DIFF
--- a/app/src/modules/queries/sampleQueries.js
+++ b/app/src/modules/queries/sampleQueries.js
@@ -9,6 +9,7 @@ export default {
   header: (
     sampleId
   ) => `${commonPrefixes}SELECT DISTINCT (REPLACE(STR(?doi),"http://dx.doi.org/","") AS ?DOI) ?sample_label ?process_label WHERE {
+  VALUES ?sample {<http://materialsmine.org/sample/${sampleId}>}
   ?sample a mm:PolymerNanocomposite ;
           rdfs:label ?sample_label ;
           prov:wasGeneratedBy [ a ?ProcessType ] .
@@ -16,11 +17,12 @@ export default {
        sio:hasPart ?sample.
   ?ProcessType rdfs:label ?process_label .
   FILTER(REGEX(STR(?ProcessType),"materialsmine"))
-} VALUES ?sample {<http://materialsmine.org/sample/${sampleId}>}`,
+}`,
 
   curatedProperties: (
     sampleId
   ) => `${commonPrefixes}SELECT DISTINCT ?AttrType ?value (GROUP_CONCAT(DISTINCT ?unit; SEPARATOR="; ") AS ?Units) WHERE {
+    VALUES ?sample { <http://materialsmine.org/sample/${sampleId}> }
       ?sample a mm:PolymerNanocomposite ;
               sio:hasAttribute ?attr .
       FILTER NOT EXISTS { ?attr sio:inRelationTo ?otherAttr }
@@ -29,21 +31,22 @@ export default {
       OPTIONAL {
         ?attr sio:hasUnit [ rdfs:label ?unit ]
       }
-    } GROUP BY ?attr ?AttrType ?value 
-    VALUES ?sample { <http://materialsmine.org/sample/${sampleId}> }`,
+    } GROUP BY ?attr ?AttrType ?value `,
 
   sampleImages: (sampleId) => `${commonPrefixes}SELECT DISTINCT * WHERE {
+    VALUES ?sample { <http://materialsmine.org/sample/${sampleId}>}
     ?sample a mm:PolymerNanocomposite ;
             sio:isRepresentedBy ?image .
     ?image a sio:Image .
     FILTER(!REGEX(STR(?image),"localhost"))
     FILTER(!REGEX(STR(?image),"XMLCONV"))
     FILTER(!REGEX(STR(?image),"nanomine"))
-  } VALUES ?sample { <http://materialsmine.org/sample/${sampleId}>}`,
+  }`,
 
   materialComponents: (
     sampleId
   ) => `${commonPrefixes}SELECT DISTINCT ?std_name ?role ?attrType ?attrValue (GROUP_CONCAT(DISTINCT ?AttrUnit; SEPARATOR="; ") AS ?attrUnits) ?fullLabel WHERE {
+    VALUES ?sample {<http://materialsmine.org/sample/${sampleId}>}
     {
       ?sample a mm:PolymerNanocomposite ;
               rdfs:label ?fullLabel ;
@@ -71,8 +74,7 @@ export default {
         ?attr sio:hasUnit [ rdfs:label ?AttrUnit ]
       }
     }
-  } GROUP BY ?std_name ?role ?attrType ?attrValue ?fullLabel ORDER BY ?std_name ?role ?AttrType
-  VALUES ?sample {<http://materialsmine.org/sample/${sampleId}>}`,
+  } GROUP BY ?std_name ?role ?attrType ?attrValue ?fullLabel ORDER BY ?std_name ?role ?AttrType`,
 
   processingSteps: (
     sampleId
@@ -80,39 +82,38 @@ export default {
   WHERE {
     {
       SELECT ?step ?param_label (MIN(?AttrLabel) AS ?attr) ?value (MIN(?unit) AS ?unit_label) WHERE {
+        VALUES ?sample {  <http://materialsmine.org/sample/${sampleId}> }
         ?sample a mm:PolymerNanocomposite ;
                 prov:wasGeneratedBy [ a ?ProcessType ;
                                       sio:hasPart ?step ] .
-        OPTIONAL {
-          ?step sio:hasParameter ?param .
-          ?param sio:hasAttribute [ a ?AttrType ; sio:hasValue ?value ] .
-          ?AttrType rdfs:label ?AttrLabel .
-        }
-        OPTIONAL {
-          ?step sio:hasParameter ?param .
-          ?param sio:hasAttribute [ a ?AttrType ; sio:hasValue ?value ; sio:hasUnit [ rdfs:label ?unit ] ] .
-          ?AttrType rdfs:label ?AttrLabel .
-        }
         ?step a [ rdfs:label ?step_type ] .
-        ?param a ?param_type .
-        ?param_type rdfs:label ?param_label .
+        OPTIONAL {
+          ?step sio:hasParameter ?param .
+          ?param sio:hasAttribute ?param_attr .
+          ?param_attr a [rdfs:label ?AttrLabel] ; sio:hasValue ?value .
+          OPTIONAL {
+          	?param_attr sio:hasUnit [ rdfs:label ?unit ] .
+          }
+          ?param a ?param_type .
+          ?param_type rdfs:label ?param_label .
+        }
         FILTER(REGEX(STR(?ProcessType),"materialsmine"))
         FILTER(REGEX(STR(?param_type),"materialsmine"))
       } GROUP BY ?step ?param_label ?value ORDER BY ?attr
-      VALUES ?sample { <http://materialsmine.org/sample/${sampleId}>}
     }
     BIND(IF(BOUND(?unit_label), CONCAT(?attr, ": ", ?value, " ", ?unit_label), CONCAT(?attr, ": ", ?value)) AS ?ParamDescr)
   } GROUP BY ?step ?param_label ORDER BY ?step`,
 
   otherSamples: (sampleId) => `${commonPrefixes}SELECT DISTINCT ?sample WHERE {
+    VALUES ?this { <http://materialsmine.org/sample/${sampleId}>}
     ?doi sio:hasPart ?this, ?sample .
     ?sample a mm:PolymerNanocomposite .
     FILTER(?this != ?sample)
-  } 
-  VALUES ?this { <http://materialsmine.org/sample/${sampleId}>}`,
+  } `,
 
   processLabel: (sampleId) => `${commonPrefixes}
   SELECT DISTINCT (REPLACE(STR(?doi),"http://dx.doi.org/","") AS ?DOI) ?sample_label ?process_label WHERE {
+    VALUES ?sample { <http://materialsmine.org/sample/${sampleId}>}
     ?sample a mm:PolymerNanocomposite ;
             rdfs:label ?sample_label ;
             prov:wasGeneratedBy [ a ?ProcessType ] .
@@ -120,7 +121,7 @@ export default {
          sio:hasPart ?sample.
     ?ProcessType rdfs:label ?process_label .
     FILTER(REGEX(STR(?ProcessType),"materialsmine"))
-  } VALUES ?sample { <http://materialsmine.org/sample/${sampleId}>}`,
+  }`,
 
   facetFilterMaterial: () => `PREFIX rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
   PREFIX rdfs: <http://www.w3.org/2000/01/rdf-schema#>

--- a/app/src/modules/vega-chart.js
+++ b/app/src/modules/vega-chart.js
@@ -62,7 +62,8 @@ const chartQuery = `
   `
 
 async function loadChart (chartUri) {
-  const singleChartQuery = chartQuery + `\n  VALUES (?uri) { (<${chartUri}>) }`
+  const valuesBlock = `\n  VALUES (?uri) { (<${chartUri}>) }`
+  const singleChartQuery = chartQuery.replace(/(where\s*{)/i, '$1' + valuesBlock)
   const { results } = await querySparql(singleChartQuery)
   const rows = results.bindings
   if (rows.length < 1) {


### PR DESCRIPTION
Some of the sample queries were causing Fuseki to crash. This PR refactors each of those queries
- Moved all `VALUES` bindings to the beginning of queries, both for samples and also for the individual chart query
- Some triples in the processing steps query needed to be moved into the `OPTIONAL` clause
- Made the `OPTIONAL` nested

Fixes #366 