### PR TITLE
fix(frontend): update chart links in explorer

### DIFF
--- a/app/src/components/explorer/SearchResultsTable.vue
+++ b/app/src/components/explorer/SearchResultsTable.vue
@@ -85,7 +85,7 @@
           <md-card-media-cover md-solid>
             <md-card-media md-ratio="4:3"  v-if="result.thumbnail">
               <img
-                :src="baseUrl + '/api/knowledge/images?uri=' + result.thumbnail.split('=')[1]"
+                :src="baseUrl + '/api/knowledge/images?uri=' + result.thumbnail"
                 :alt="result.label"
                 v-if="result.thumbnail"
               >

--- a/app/src/modules/vega-chart.js
+++ b/app/src/modules/vega-chart.js
@@ -149,7 +149,7 @@ async function loadChart (chartUri) {
     chartUrl = decodeURIComponent(chartUri.split('view/')[1])
   }
 
-  const valuesBlock = `\n  VALUES (?uri) { (<${chartUri}>) }`
+  const valuesBlock = `\n  VALUES (?uri) { (<${chartUrl}>) }`
   const singleChartQuery = chartQuery.replace(/(where\s*{)/i, '$1' + valuesBlock)
   const { results } = await querySparql(singleChartQuery)
   const rows = results.bindings


### PR DESCRIPTION
This fixes vega-chart.js passing the wrong arg for loading purl charts
Also fixes explorer charts that were not properly loading thumbnails