### PR TITLE
fix(frontend): refactor yasqe to pass queries to chart editor

### DIFF
--- a/app/src/components/explorer/yasqe.vue
+++ b/app/src/components/explorer/yasqe.vue
@@ -55,6 +55,7 @@ export default {
       yasqeContext.$emit('query-error', arguments)
     })
     this.yasqe.on('queryResults', function (yasqe, response, duration) {
+      yasqeContext.$emit('input', yasqeContext.yasqe.getValue())
       yasqeContext.$emit('query-success', response)
     })
   },

--- a/app/src/pages/explorer/chart/editor/Chart.vue
+++ b/app/src/pages/explorer/chart/editor/Chart.vue
@@ -16,6 +16,7 @@
         <yasqe
           v-if="chart.query"
           v-model="chart.query"
+          :value="chart.query"
           v-on:query-success="onQuerySuccess"
           v-show="leftTab === 1" :showBtns='true'>
         </yasqe>

--- a/app/src/pages/explorer/parameterized-query/parameterized-query-page.vue
+++ b/app/src/pages/explorer/parameterized-query/parameterized-query-page.vue
@@ -65,6 +65,7 @@
           <yasqe
             :value="query"
             :readOnly="true"
+            :showBtns="false"
           ></yasqe>
         </accordion>
       </div>


### PR DESCRIPTION
This PR fixes the error where new charts were returning the wrong SPARQL query (and therefore appearing blank).
Yasqe was only returning the **query response** and not the properly synced **query value** to chart editor UI, so all newly created charts were saving with the default query (even though they may have looked correct while still in the editor). It now passes back the correct, updated query whenever a query is run. 

Also temporarily disables `showBtns` arg in the parameterized query yasqe, since that button doesn't currently work with the other existing "run query" button

Definitely works on my local system, but I would strongly recommend testing it on other builds.

This PR does NOT currently fix the error where only one chart is shown at a time in the gallery.