### PR TITLE
#373 fix chart editing and deletion

### DIFF
--- a/app/src/assets/css/modules/_utility.scss
+++ b/app/src/assets/css/modules/_utility.scss
@@ -593,20 +593,28 @@
     &-gridicon {
         position: absolute;
         right: 4.5rem;
+        top: 16rem;
         z-index: 10000000;
         @include respond(tab-land){
             right: 2.5rem;
+            top: 19rem;
+        }
+        @include respond(phone) {
+            top: 15rem;
         }
         & > div {
             display: inline-block;
-
-            & > i {
-                font-size: 1rem !important;
-                width: 21px !important;
-                min-width: 21px !important;
-                height: 21px !important; 
-                cursor: pointer;
-            }
+        }
+        .md-icon-button {
+            width: 3rem !important;
+            min-width: 3rem !important
+        }
+        .md-icon {
+            font-size: 2.5rem !important;
+            width: 2.5rem !important;
+            min-width: 2.5rem !important;
+            height: 2.5rem !important; 
+            cursor: pointer;
         }
 
         &_explorer {

--- a/app/src/components/nanomine/ImageUpload.vue
+++ b/app/src/components/nanomine/ImageUpload.vue
@@ -321,7 +321,7 @@ export default {
         } else if (this.inputtedDimensions.units === 'millimeters') {
           ratio = ratio / 1000
         }
-        // console.log(this.displayedFiles[0].size.width, this.displayedFiles[0].pixelSize.width)
+
         this.selectedOptions.dimensions = { units: this.inputtedDimensions.units, width: this.displayedFiles[0].size.width, height: this.displayedFiles[0].size.height, ratio: ratio }
       } else {
         this.selectedOptions.dimensions = { units: this.inputtedDimensions.units, width: parseInt(this.inputtedDimensions.width), height: parseInt(this.inputtedDimensions.height), ratio: null }

--- a/app/src/modules/vega-chart.js
+++ b/app/src/modules/vega-chart.js
@@ -149,6 +149,9 @@ async function loadChart (chartUri) {
     // lodPrefix is now fixed (e.g. http://nanomine.org/viz/chartId instead of http://purl.org/chart/view/chartId)
     // Todo (ticket-xx): Remove this if logic if response is consistent
     chartUrl = decodeURIComponent(chartUri.split('view/')[1])
+  } else if ( !chartUri.startsWith('http') ) {
+    // This is currently needed for editing since gallery only passes ID and not the full uri
+    chartUrl = `${chartUriPrefix}${chartUri}`
   }
 
   const valuesBlock = `\n  VALUES (?uri) { (<${chartUrl}>) }`
@@ -214,8 +217,8 @@ function toChartUri (chartId) {
   return chartUriPrefix + chartId
 }
 
-function shareChartUri (chartId) {
+function shareableChartUri (chartId) {
   return `${window.location.origin}/explorer/chart/view/${chartId}`
 }
 
-export { getDefaultChart, saveChart, loadChart, copyChart, buildSparqlSpec, buildCsvSpec, toChartId, toChartUri, shareChartUri, chartUriPrefix }
+export { getDefaultChart, saveChart, deleteChart, loadChart, copyChart, buildSparqlSpec, buildCsvSpec, toChartId, toChartUri, shareableChartUri, chartUriPrefix }

--- a/app/src/modules/vega-chart.js
+++ b/app/src/modules/vega-chart.js
@@ -149,7 +149,7 @@ async function loadChart (chartUri) {
     // lodPrefix is now fixed (e.g. http://nanomine.org/viz/chartId instead of http://purl.org/chart/view/chartId)
     // Todo (ticket-xx): Remove this if logic if response is consistent
     chartUrl = decodeURIComponent(chartUri.split('view/')[1])
-  } else if ( !chartUri.startsWith('http') ) {
+  } else if (!chartUri.startsWith('http')) {
     // This is currently needed for editing since gallery only passes ID and not the full uri
     chartUrl = `${chartUriPrefix}${chartUri}`
   }

--- a/app/src/pages/explorer/Gallery.vue
+++ b/app/src/pages/explorer/Gallery.vue
@@ -93,16 +93,16 @@
             with identifier <b>{{dialog.chart.identifier}}</b>.
           </md-content>
         </div>
-        <div v-if="dialogLoading">      
+        <div v-if="dialogLoading">
           <spinner
             :loading="dialogLoading"
             text='Deleting Chart'
           />
         </div>
-      </template> 
+      </template>
       <template v-slot:actions>
         <span v-if="dialog.type=='delete' && dialog.chart">
-          <md-button @click.native.prevent="toggleDialogBox"> 
+          <md-button @click.native.prevent="toggleDialogBox">
             No, cancel
           </md-button>
           <md-button @click.native.prevent="deleteChart(dialog.chart)">
@@ -172,8 +172,8 @@ export default {
     async deleteChart (chart) {
       if (!this.isAdmin) return // temporary safeguard
       this.dialogLoading = true
-      await this.$store.dispatch('explorer/curation/deleteChartNanopub', chart.identifier )
-      await this.$store.dispatch('explorer/curation/deleteChartES', chart.identifier )
+      await this.$store.dispatch('explorer/curation/deleteChartNanopub', chart.identifier)
+      await this.$store.dispatch('explorer/curation/deleteChartES', chart.identifier)
       this.toggleDialogBox()
       this.dialogLoading = false
       await this.loadItems()

--- a/app/src/pages/explorer/chart/editor/Chart.vue
+++ b/app/src/pages/explorer/chart/editor/Chart.vue
@@ -177,7 +177,6 @@ export default {
         if (this.$route.params.type === 'new') {
           // Save chart to MongoDB - async operation
         } else {
-          console.log('charturi:', this.chartId)
           await this.$store.dispatch('explorer/curation/deleteChartES', `http://nanomine.org/viz/${this.chartId}`)
           // Find in mongo and update - async operation
         }

--- a/app/src/pages/explorer/chart/editor/Chart.vue
+++ b/app/src/pages/explorer/chart/editor/Chart.vue
@@ -1,0 +1,209 @@
+<template>
+  <div class="chart_editor">
+    <div class="u--layout-width viz-sample u--layout-flex utility_flex_mobile" >
+      <div v-if="loading" class="editImage_modal" style="z-index:4">
+        <spinner :loading="loading"/>
+      </div>
+     <!-- Left element -->
+    <div class="chart_editor__left-view" style="flex: 1 1 50%;">
+      <div class="u--layout-width u--layout-flex u--layout-flex-justify-fs u_margin-bottom-small">
+        <a @click.prevent="leftTab = 1" :class="[leftTab === 1 ? 'active u--color-primary' : '']" class="viz-tab__button">Sparql</a>
+        <a @click.prevent="leftTab = 2" :class="[leftTab === 2 ? 'active u--color-primary' : '']" class="viz-tab__button">Vega</a>
+        <a @click.prevent="leftTab = 3" :class="[leftTab === 3 ? 'active u--color-primary' : '']" class="viz-tab__button">Save Chart</a>
+      </div>
+
+      <div class="chart_editor__left-content">
+        <yasqe
+          v-if="chart.query"
+          v-model="chart.query"
+          v-on:query-success="onQuerySuccess"
+          v-show="leftTab === 1" :showBtns='true'>
+        </yasqe>
+        <v-jsoneditor v-show="leftTab === 2"
+          v-model="chart.baseSpec"
+          :options="specJsonEditorOpts"
+          v-if="chart.baseSpec"
+        > </v-jsoneditor>
+        <form v-show="leftTab === 3">
+          <md-field>
+            <label>Title</label>
+            <md-input v-model="chart.title"></md-input>
+          </md-field>
+
+          <md-field>
+            <label>Description</label>
+            <md-textarea v-model="chart.description"></md-textarea>
+          </md-field>
+
+          <button class="btn btn--primary" @click.prevent="saveChart"> {{ actionType }}  <md-icon class="u--color-success">check</md-icon> </button>
+        </form>
+      </div>
+
+    </div>
+
+    <!-- The resizer -->
+    <div class="u_height--max u--bg-grey u_pointer--ew md-xsmall-hide chart_editor-divider"  id="dragMe"></div>
+
+    <!-- Right element -->
+    <div class="chart_editor__right-view" style="flex: 1 1 50%;">
+      <h4 class="u--margin-pos">Preview</h4>
+      <div class="u--layout-width u--layout-flex u--layout-flex-justify-end u_margin-bottom-small">
+        <a @click.prevent="rightTab = 1" :class="[rightTab === 1 ? 'active u--color-primary' : '']" class="viz-tab__button">Chart</a>
+        <a @click.prevent="rightTab = 2" :class="[rightTab === 2 ? 'active u--color-primary' : '']" class="viz-tab__button">Table</a>
+      </div>
+
+      <div class="chart_editor__right-content">
+        <div  v-show="rightTab === 1" class="loading-dialog" style="margin: auto">
+          <vega-lite :spec="spec" @new-vega-view="onNewVegaView" class="btn--animated vega-embed-chartview"/>
+        </div>
+
+        <div v-show="rightTab === 2"  class="viz-intro-query" style="min-height: 40rem !important">
+            <yasr :results="results"></yasr>
+        </div>
+      </div>
+    </div>
+
+    </div>
+    <md-button @click="goToExplorer" class="md-fab md-fixed md-fab-bottom-right md-primary btn--primary">
+        <md-icon>arrow_back</md-icon>
+    </md-button>
+  </div>
+</template>
+
+<script>
+import { querySparql } from '@/modules/sparql'
+import { saveChart, getDefaultChart, buildSparqlSpec } from '@/modules/vega-chart'
+import VJsoneditor from 'v-jsoneditor'
+import VegaLite from '@/components/explorer/VegaLiteWrapper.vue'
+import yasqe from '@/components/explorer/yasqe'
+import yasr from '@/components/explorer/yasr'
+import spinner from '@/components/Spinner'
+export default {
+  name: 'ChartCreate',
+  components: {
+    VJsoneditor,
+    VegaLite,
+    yasqe,
+    yasr,
+    spinner
+  },
+  data () {
+    return {
+      loading: true,
+      mouseIsDown: false,
+      x: 0,
+      y: 0,
+      leftTab: 1,
+      rightTab: 1,
+      results: null,
+      specJsonEditorOpts: {
+        mode: 'code',
+        mainMenuBar: false
+      },
+      chart: {
+        baseSpec: null,
+        query: null,
+        title: null,
+        description: null
+      },
+      actionType: 'Save Chart',
+      sumbmittedIdentifier: undefined
+    }
+  },
+  computed: {
+    spec () {
+      const spec = buildSparqlSpec(this.chart.baseSpec, this.results) ?? {}
+      return spec
+    }
+  },
+  methods: {
+    getSparqlData () {
+      const vm = this
+      querySparql(vm.chart.query)
+        .then(this.onQuerySuccess)
+        .then(this.loading = false)
+    },
+    onQuerySuccess (results) {
+      this.results = results
+    },
+    onSpecJsonError () {
+      console.log('bad', arguments)
+    },
+    async onNewVegaView (view) {
+      const blob = await view.toImageURL('png')
+        .then(url => fetch(url))
+        .then(resp => resp.blob())
+      const fr = new FileReader()
+      fr.addEventListener('load', () => {
+        this.chart.depiction = fr.result
+      })
+      fr.readAsDataURL(blob)
+    },
+    async loadChart () {
+      // this.types = 'new, edit, restore & delete'
+      let getChartPromise
+      if (this.$route.params.type === 'new') {
+        this.actionType = 'Save Chart'
+        getChartPromise = Promise.resolve(getDefaultChart())
+      } else if (this.$route.params.type === 'edit') {
+        // fetch chart from knowledge graph
+        this.actionType = 'Edit Chart'
+      } else {
+        // Get chart from mongo backup
+        this.actionType = 'Restore Chart'
+        this.reloadRestored()
+      }
+      getChartPromise
+        .then(chart => {
+          this.chart = chart
+          return this.getSparqlData()
+        })
+    },
+    async reloadRestored () {
+      // 1. Fetch backup from mongo
+      // 2. Post each chart (schema + sparql) to knowledge graph
+      // 3. Toggle restore flag in mongo
+
+    },
+    async saveChart () {
+      // Todo (ticket xx): Move this into vuex
+      try {
+        const chartNanopub = await saveChart(this.chart)
+
+        const resp = await this.$store.dispatch('explorer/curation/cacheNewChartResponse', {
+          identifier: this.sumbmittedIdentifier,
+          chartNanopub
+        })
+
+        if (resp.identifier) {
+          this.sumbmittedIdentifier = resp.identifier
+        }
+
+        if (this.$route.params.type === 'new') {
+          // Save chart to MongoDB - async operation
+        } else {
+          // Find in mongo and update - async operation
+        }
+        this.$store.commit('explorer/curation/setNewChartExist', true)
+
+        // Change button name after submission
+        this.actionType = 'Edit Chart'
+        this.$store.commit('setSnackbar', {
+          message: 'Chart saved successfully!',
+          duration: 5000
+        })
+      } catch (err) {
+        // TODO (Ticket xxx): USE THE APP DIALOGUE BOX INSTEAD OF ALERT BOX
+        return alert(err)
+      }
+    },
+    goToExplorer () {
+      this.$router.push('/explorer/chart')
+    }
+  },
+  created () {
+    this.loading = true
+    this.loadChart()
+  }
+}
+</script>

--- a/app/src/pages/explorer/chart/editor/Chart.vue
+++ b/app/src/pages/explorer/chart/editor/Chart.vue
@@ -169,9 +169,18 @@ export default {
 
     },
     async saveChart () {
+      this.loading = true
       // Todo (ticket xx): Move this into vuex
       try {
         const chartNanopub = await saveChart(this.chart)
+
+        if (this.$route.params.type === 'new') {
+          // Save chart to MongoDB - async operation
+        } else {
+          console.log('charturi:', this.chartId)
+          await this.$store.dispatch('explorer/curation/deleteChartES', `http://nanomine.org/viz/${this.chartId}`)
+          // Find in mongo and update - async operation
+        }
 
         const resp = await this.$store.dispatch('explorer/curation/cacheNewChartResponse', {
           identifier: this.submittedIdentifier,
@@ -182,13 +191,8 @@ export default {
           this.submittedIdentifier = resp.identifier
         }
 
-        if (this.$route.params.type === 'new') {
-          // Save chart to MongoDB - async operation
-        } else {
-          // Find in mongo and update - async operation
-        }
         this.$store.commit('explorer/curation/setNewChartExist', true)
-
+        this.loading = false
         // Change button name after submission
         this.actionType = 'Edit Chart'
         this.$store.commit('setSnackbar', {

--- a/app/src/pages/explorer/chart/editor/Chart.vue
+++ b/app/src/pages/explorer/chart/editor/Chart.vue
@@ -108,7 +108,7 @@ export default {
         description: null
       },
       actionType: 'Save Chart',
-      sumbmittedIdentifier: undefined
+      submittedIdentifier: undefined
     }
   },
   props: ['chartId'],
@@ -174,12 +174,12 @@ export default {
         const chartNanopub = await saveChart(this.chart)
 
         const resp = await this.$store.dispatch('explorer/curation/cacheNewChartResponse', {
-          identifier: this.sumbmittedIdentifier,
+          identifier: this.submittedIdentifier,
           chartNanopub
         })
 
         if (resp.identifier) {
-          this.sumbmittedIdentifier = resp.identifier
+          this.submittedIdentifier = resp.identifier
         }
 
         if (this.$route.params.type === 'new') {

--- a/app/src/pages/explorer/chart/editor/Chart.vue
+++ b/app/src/pages/explorer/chart/editor/Chart.vue
@@ -73,7 +73,7 @@
 
 <script>
 import { querySparql } from '@/modules/sparql'
-import { saveChart, getDefaultChart, buildSparqlSpec } from '@/modules/vega-chart'
+import { saveChart, getDefaultChart, buildSparqlSpec, loadChart } from '@/modules/vega-chart'
 import VJsoneditor from 'v-jsoneditor'
 import VegaLite from '@/components/explorer/VegaLiteWrapper.vue'
 import yasqe from '@/components/explorer/yasqe'
@@ -111,6 +111,7 @@ export default {
       sumbmittedIdentifier: undefined
     }
   },
+  props: ['chartId'],
   computed: {
     spec () {
       const spec = buildSparqlSpec(this.chart.baseSpec, this.results) ?? {}
@@ -149,6 +150,7 @@ export default {
       } else if (this.$route.params.type === 'edit') {
         // fetch chart from knowledge graph
         this.actionType = 'Edit Chart'
+        getChartPromise = Promise.resolve(loadChart(this.chartId))
       } else {
         // Get chart from mongo backup
         this.actionType = 'Restore Chart'

--- a/app/src/pages/explorer/chart/view/vega-view-script.js
+++ b/app/src/pages/explorer/chart/view/vega-view-script.js
@@ -52,7 +52,7 @@ export default {
     ...mapGetters({
       dialogBoxActive: 'dialogBox',
       isAuth: 'auth/isAuthenticated',
-      isAdmin: 'auth/isAdmin',
+      isAdmin: 'auth/isAdmin'
     }),
     specViewerSpec () {
       return this.specViewer.includeData ? this.spec : this.chart && this.chart.baseSpec
@@ -87,11 +87,11 @@ export default {
     editChart () {
       return this.$router.push(`/explorer/chart/editor/edit/${this.chartId}`)
     },
-    async deleteChart() {
+    async deleteChart () {
       if (!this.isAdmin) return // temporary safeguard
       this.dialogLoading = true
-      await this.$store.dispatch('explorer/curation/deleteChartNanopub', this.chart.uri )
-      await this.$store.dispatch('explorer/curation/deleteChartES', this.chart.uri )
+      await this.$store.dispatch('explorer/curation/deleteChartNanopub', this.chart.uri)
+      await this.$store.dispatch('explorer/curation/deleteChartES', this.chart.uri)
       this.toggleDialogBox()
       this.dialogLoading = false
       this.$router.push('/explorer/chart')

--- a/app/src/pages/explorer/chart/view/vega-view-script.js
+++ b/app/src/pages/explorer/chart/view/vega-view-script.js
@@ -1,6 +1,6 @@
 import VJsoneditor from 'v-jsoneditor'
 import Dialog from '@/components/Dialog.vue'
-import { loadChart, buildSparqlSpec, toChartUri, shareChartUri } from '@/modules/vega-chart'
+import { loadChart, buildSparqlSpec, toChartUri, shareableChartUri } from '@/modules/vega-chart'
 import VegaLite from '@/components/explorer/VegaLiteWrapper.vue'
 import yasqe from '@/components/explorer/yasqe'
 import yasr from '@/components/explorer/yasr'
@@ -43,13 +43,16 @@ export default {
       results: null,
       dialog: {
         title: ''
-      }
+      },
+      dialogLoading: false
     }
   },
   props: ['chartId'],
   computed: {
     ...mapGetters({
-      dialogBoxActive: 'dialogBox'
+      dialogBoxActive: 'dialogBox',
+      isAuth: 'auth/isAuthenticated',
+      isAdmin: 'auth/isAdmin',
     }),
     specViewerSpec () {
       return this.specViewer.includeData ? this.spec : this.chart && this.chart.baseSpec
@@ -57,8 +60,8 @@ export default {
     fullChartUri () {
       return toChartUri(this.chartId)
     },
-    shareChartUri () {
-      return shareChartUri(this.chartId)
+    shareableChartUri () {
+      return shareableChartUri(this.chartId)
     }
   },
   methods: {
@@ -82,6 +85,16 @@ export default {
       this.$router.push('/explorer/chart')
     },
     editChart () {
+      return this.$router.push(`/explorer/chart/editor/edit/${this.chartId}`)
+    },
+    async deleteChart() {
+      if (!this.isAdmin) return // temporary safeguard
+      this.dialogLoading = true
+      await this.$store.dispatch('explorer/curation/deleteChartNanopub', this.chart.uri )
+      await this.$store.dispatch('explorer/curation/deleteChartES', this.chart.uri )
+      this.toggleDialogBox()
+      this.dialogLoading = false
+      this.$router.push('/explorer/chart')
     },
     renderDialog (title, type, minWidth) {
       this.dialog = {

--- a/app/src/pages/explorer/chart/view/vega-view-script.js
+++ b/app/src/pages/explorer/chart/view/vega-view-script.js
@@ -1,6 +1,6 @@
 import VJsoneditor from 'v-jsoneditor'
 import Dialog from '@/components/Dialog.vue'
-import { loadChart, buildSparqlSpec, toChartUri } from '@/modules/vega-chart'
+import { loadChart, buildSparqlSpec, toChartUri, shareChartUri } from '@/modules/vega-chart'
 import VegaLite from '@/components/explorer/VegaLiteWrapper.vue'
 import yasqe from '@/components/explorer/yasqe'
 import yasr from '@/components/explorer/yasr'
@@ -56,6 +56,9 @@ export default {
     },
     fullChartUri () {
       return toChartUri(this.chartId)
+    },
+    shareChartUri () {
+      return shareChartUri(this.chartId)
     }
   },
   methods: {

--- a/app/src/pages/explorer/chart/view/vega-view.html
+++ b/app/src/pages/explorer/chart/view/vega-view.html
@@ -92,7 +92,7 @@
     <template v-slot:content>
         <div v-if="dialog.type=='share'">
             <md-field> <label>Chart Link</label>
-                <md-textarea disabled v-model="fullChartUri"></md-textarea>
+                <md-textarea disabled v-model="shareChartUri"></md-textarea>
             </md-field>
             <div>Copy the link above to share this chart</div>
         </div>

--- a/app/src/pages/explorer/chart/view/vega-view.html
+++ b/app/src/pages/explorer/chart/view/vega-view.html
@@ -33,11 +33,15 @@
                 <md-icon>dynamic_form</md-icon>
             </md-button>
         </router-link>
-        <div v-if="allowEdit">
-        <md-button disabled class="md-icon-button" @click.native.prevent="editChart">
-            <md-tooltip> Edit Chart </md-tooltip>
-            <md-icon>edit</md-icon>
-        </md-button>
+        <div v-if="isAuth && isAdmin">
+            <md-button class="md-icon-button" @click.native.prevent="editChart">
+                <md-tooltip> Edit Chart </md-tooltip>
+                <md-icon>edit</md-icon>
+            </md-button>
+            <md-button class="md-icon-button" @click.native.prevent="renderDialog('Delete Chart?', 'delete', 80)">
+                <md-tooltip> Delete Chart </md-tooltip>
+                <md-icon>delete</md-icon>
+            </md-button>
         </div>
     </div>
     </div>
@@ -92,7 +96,7 @@
     <template v-slot:content>
         <div v-if="dialog.type=='share'">
             <md-field> <label>Chart Link</label>
-                <md-textarea disabled v-model="shareChartUri"></md-textarea>
+                <md-textarea disabled v-model="shareableChartUri"></md-textarea>
             </md-field>
             <div>Copy the link above to share this chart</div>
         </div>
@@ -115,9 +119,29 @@
                 <md-checkbox v-model="specViewer.includeData">Include data in spec</md-checkbox>
             </div>
         </div>
+        <div v-if="dialog.type=='delete'">
+            <md-content>
+                <div> This will permanently remove chart <b>{{chart.title}}</b> </div>
+                with identifier <b>{{chart.uri}}</b>.
+            </md-content>
+        </div>
+        <div v-if="dialogLoading">      
+          <spinner
+            :loading="dialogLoading"
+            text='Deleting Chart'
+          />
+        </div>
     </template> 
     <template v-slot:actions>
-        <md-button @click.native.prevent="toggleDialogBox">Close</md-button>
+        <span v-if="dialog.type=='delete'">
+            <md-button @click.native.prevent="toggleDialogBox"> 
+                No, cancel
+            </md-button>
+            <md-button @click.native.prevent="deleteChart">
+                Yes, delete.
+            </md-button>
+        </span>
+        <md-button v-else @click.native.prevent="toggleDialogBox">Close</md-button>
     </template>
 </dialogbox>
 </div>

--- a/app/src/router/module/explorer.js
+++ b/app/src/router/module/explorer.js
@@ -120,21 +120,22 @@ const explorerRoutes = [
         component: () => import('@/pages/explorer/Gallery.vue'),
         meta: { requiresAuth: false }
       },
-      ...['editor/:type', 'editor/:type/:chartId']
+      ...['editor/:type', 'editor/:type/:chartId(.*)']
         .map(path => ({
           path,
           component: () => import('@/pages/explorer/chart/editor/Chart.vue'),
+          props: true,
           meta: { requiresAuth: true }
         })),
       {
-        path: 'view/:chartId',
+        path: 'view/:chartId(.*)',
         name: 'ChartView',
         component: () => import('@/pages/explorer/chart/view/VegaView.vue'),
         props: true,
         meta: { requiresAuth: false }
       },
       {
-        path: 'voyager/:chartId',
+        path: 'voyager/:chartId(.*)',
         name: 'ChartDataVoyager',
         component: () => import('@/pages/explorer/chart/datavoyager/DataVoyagerPage.vue'),
         props: true,

--- a/app/src/store/modules/auth/actions.js
+++ b/app/src/store/modules/auth/actions.js
@@ -59,7 +59,7 @@ export default {
     const token = res.token ?? null
     const userId = res.userId ?? null
     const displayName = res.displayName ?? null
-    const isAdmin = res.isAdmin ? res.isAdmin : false
+    const isAdmin = res.isAdmin ?? false
     const expiresIn = 9000 * 60 * 60
     const expirationDate = new Date().getTime() + expiresIn
 
@@ -112,7 +112,8 @@ export default {
     context.commit('setUser', {
       token: null,
       userId: null,
-      displayName: null
+      displayName: null,
+      isAdmin: false
     })
 
     const meta = router.currentRoute?.meta

--- a/app/src/store/modules/auth/mutations.js
+++ b/app/src/store/modules/auth/mutations.js
@@ -3,6 +3,7 @@ export default {
     state.token = payload.token
     state.userId = payload.userId
     state.displayName = payload.displayName
+    state.isAdmin = payload.isAdmin
     state.didAutoLogout = false
   },
   setAutoLogout (state) {

--- a/app/src/store/modules/explorer/curation/actions.js
+++ b/app/src/store/modules/explorer/curation/actions.js
@@ -23,5 +23,58 @@ export default {
         }, { root: true })
       }
     })
+  },
+
+  async createChartInstanceObject (_context, nanopubPayload) {
+    const chartObject = nanopubPayload?.['@graph']?.['np:hasAssertion']?.['@graph'][0]
+
+    // Return if not able to retrieve chart object
+    if (!chartObject) return new Error('Caching error. Chart object is missing')
+
+    // Build chart instance object
+    return {
+      description: chartObject['http://purl.org/dc/terms/description']?.[0]?.['@value'],
+      identifier: chartObject['@id'],
+      label: chartObject['http://purl.org/dc/terms/title']?.[0]?.['@value'],
+      thumbnail: chartObject['http://xmlns.com/foaf/0.1/depiction']?.['@id']
+      // depiction: chartObject['http://xmlns.com/foaf/0.1/depiction']?.['http://vocab.rpi.edu/whyis/hasContent']
+    }
+  },
+
+  async cacheNewChartResponse ({ commit, dispatch, rootGetters }, payload) {
+    const { identifier, chartNanopub } = payload
+    const url = '/api/admin/es'
+    const chartInstanceObject = await dispatch('createChartInstanceObject', chartNanopub)
+    const token = rootGetters['auth/token']
+
+    // 1. Check if a chart with same identifier exist in ES and delete
+    if (identifier) {
+      await fetch(url, {
+        method: 'DELETE',
+        headers: {
+          Accept: 'application/json',
+          'Content-Type': 'application/json',
+          Authorization: 'Bearer ' + token
+        },
+        body: JSON.stringify({ doc: identifier, type: 'charts' })
+      })
+    }
+
+    const fetchResponse = await fetch(url, {
+      method: 'PUT',
+      headers: {
+        Accept: 'application/json',
+        'Content-Type': 'application/json',
+        Authorization: 'Bearer ' + token
+      },
+      body: JSON.stringify({ doc: chartInstanceObject, type: 'charts' })
+    })
+
+    if (fetchResponse.status !== 200) {
+      return new Error(fetchResponse.statusText || 'Server error, cannot cache chart')
+    }
+
+    const response = await fetchResponse.json()
+    return { response, identifier: chartInstanceObject.identifier }
   }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -160,7 +160,7 @@ services:
     environment:
 #      - ADMIN_USER=admin
 #      - ADMIN_PASSWORD=${ADMIN_PASSWORD}
-      - JVM_ARGS=-Xmx10g
+      - JVM_ARGS=-Xmx4g
       - FUSEKI_BASE=/fuseki
     ports:
       - '3030:3030'

--- a/resfulservice/config/constant.js
+++ b/resfulservice/config/constant.js
@@ -5,5 +5,9 @@ module.exports = {
   images: 'about?view=instances&uri=http://semanticscience.org/resource/Image',
   charts: 'about?view=instances&uri=http://semanticscience.org/resource/Chart',
   sparql: 'sparql',
-  supportedBrowser: ['Firefox', 'Chrome', 'Canary', 'Safari', 'Opera', 'IE']
+  supportedBrowser: ['Firefox', 'Chrome', 'Canary', 'Safari', 'Opera', 'IE'],
+  userRoles: {
+    isAdmin: 'isAdmin',
+    member: 'member'
+  }
 };

--- a/resfulservice/src/controllers/adminController.js
+++ b/resfulservice/src/controllers/adminController.js
@@ -107,7 +107,9 @@ exports.loadElasticSearch = async (req, res, next) => {
   try {
     let response;
     if (req.method === 'DELETE') {
+      log.info(`loadElasticSearch(): deleting ${type} matching ${doc}`);
       response = await elasticSearch.deleteSingleDoc(type, doc);
+      log.info(`loadElasticSearch(): successfully deleted ${response.deleted} doc(s)`);
     } else {
       response = await elasticSearch.indexDocument(req, type, doc);
     }

--- a/resfulservice/src/controllers/authController.js
+++ b/resfulservice/src/controllers/authController.js
@@ -2,12 +2,14 @@ const User = require('../models/user');
 const UAParser = require('ua-parser-js');
 const { setInternal } = require('../middlewares/isInternal');
 const { successWriter, errorWriter } = require('../utils/logWriter');
-const { supportedBrowser } = require('../../config/constant');
+const { supportedBrowser, userRoles } = require('../../config/constant');
 
 // Generate and send token info to FE
-const _redirect = ({ _id, email, displayName }, req, res) => {
+const _redirect = ({ _id, email, displayName, givenName, surName, roles }, req, res) => {
+  const isAdmin = roles === userRoles.isAdmin;
+
   successWriter(req, 'success', 'Found/Created user successfully');
-  const token = setInternal(req, { _id, email, displayName });
+  const token = setInternal(req, { _id, email, displayName, givenName, surName, isAdmin });
   successWriter(req, 'success', 'Login token generated successfully');
 
   return res
@@ -15,7 +17,8 @@ const _redirect = ({ _id, email, displayName }, req, res) => {
       .stringify({
         userId: _id,
         token,
-        displayName
+        displayName,
+        isAdmin
         })}`);
 };
 

--- a/resfulservice/src/utils/elasticSearch.js
+++ b/resfulservice/src/utils/elasticSearch.js
@@ -70,7 +70,7 @@ class ElasticSearch {
       index: type,
       body: {
         query: {
-          match: {
+          match_phrase: {
             identifier
           }
         }


### PR DESCRIPTION
Fixes multiple issues with charts:
- Make charts editable from both their individual pages and the gallery
- Allow admins to delete charts (with dialog box confirmation)
- Fix the issue where elastic search would delete all charts from cache instead of just the exact match
- Standardize chart URIs to be consistent with previous implementation
- Make sure shareable chart links are permanent
- Add `(.*)` to chart routes for backwards compatibility with any purl.org charts left on QA (since otherwise Vue router misinterprets `/` symbols in URIs)

fixes #373 #372 
closes #374 (open PR that has been merged into this one) 