### PR TITLE
feat(#375): Spreadsheet curation logic

### DIFF
--- a/app/jest.config.js
+++ b/app/jest.config.js
@@ -3,7 +3,9 @@ module.exports = {
   transform: {
     '^.+\\.vue$': 'vue-jest',
     '\\.(gif)$': '<rootDir>/tests/jest/__mocks__/fileMock.js',
-    '\\.(ttl|rq)': 'jest-raw-loader'
+    '\\.(ttl|rq)': 'jest-raw-loader',
+    '^.+\\.js$': 'babel-jest',
+    '.*\\.(vue)$': 'vue-jest'
   },
   snapshotSerializers: [
     '<rootDir>/node_modules/jest-serializer-vue'
@@ -12,5 +14,13 @@ module.exports = {
     d3: '<rootDir>/node_modules/d3/dist/d3.min.js',
     'style-loader!(.*)': '<rootDir>/node_modules/style-loader'
   },
-  setupFilesAfterEnv: ['<rootDir>/tests/jest/script/test-setup.js']
+  setupFilesAfterEnv: ['<rootDir>/tests/jest/script/test-setup.js'],
+  moduleFileExtensions: ['js', 'vue', 'json'],
+  globals: {
+    'vue-jest': {
+      templateCompiler: {
+        compiler: require('vue-template-babel-compiler')
+      }
+    }
+  }
 }

--- a/resfulservice/.gitignore
+++ b/resfulservice/.gitignore
@@ -1,3 +1,7 @@
 # node
 node_modules/
 package-lock.json
+
+#ignore coverage
+coverage
+.nyc_output

--- a/resfulservice/config/xlsx.json
+++ b/resfulservice/config/xlsx.json
@@ -1,0 +1,6839 @@
+{
+  "Your Name": {
+    "value": "1. Data Origin|[2,1]",
+    "type": "String"
+  },
+  "Your Email": {
+    "value": "1. Data Origin|[3,1]",
+    "type": "String"
+  },
+  "Sample ID": {
+    "value": "1. Data Origin|[4,1]",
+    "type": "String"
+  },
+  "Control sample ID": {
+    "value": "1. Data Origin|[5,1]",
+    "type": "String"
+  },
+  "Origin": {
+    "value": "1. Data Origin|[6,1]",
+    "type": "List",
+    "validList": "origin"
+  },
+  "Citation Type": {
+    "value": "1. Data Origin|[7,1]",
+    "type": "List",
+    "validList": "citation_type"
+  },
+  "Publication Type": {
+    "value": "1. Data Origin|[8,1]",
+    "type": "List",
+    "validList": "publication_type"
+  },
+  "DOI": {
+    "value": "1. Data Origin|[10,1]",
+    "type": "String"
+  },
+  "Publication": {
+    "value": "1. Data Origin|[15,1]",
+    "type": "String"
+  },
+  "Title": {
+    "value": "1. Data Origin|[16,1]",
+    "type": "String"
+  },
+  "Publication Year": {
+    "value": "1. Data Origin|[21,1]",
+    "type": "String"
+  },
+  "Volume": {
+    "value": "1. Data Origin|[22,1]",
+    "type": "String"
+  },
+  "Issue": {
+    "value": "1. Data Origin|[23,1]",
+    "type": "String"
+  },
+  "URL": {
+    "value": "1. Data Origin|[24,1]",
+    "type": "String"
+  },
+  "Language": {
+    "value": "1. Data Origin|[25,1]",
+    "type": "String"
+  },
+  "Location": {
+    "value": "1. Data Origin|[26,1]",
+    "type": "String"
+  },
+  "Date of citation": {
+    "value": "1. Data Origin|[27,1]",
+    "type": "String"
+  },
+  "Laboratory Data Info": {
+    "Date of Sample Made": {
+      "value": "1. Data Origin|[31,1]",
+      "type": "String"
+    },
+    "Date of Data Measurement": {
+      "value": "1. Data Origin|[32,1]",
+      "type": "String"
+    },
+    "Related DOI": {
+      "value": "1. Data Origin|[33,1]",
+      "type": "String"
+    }
+  },
+  "Matrix": {
+    "Chemical name": {
+      "Description": {
+        "value": "2. Material Types|[5,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[5,4]",
+        "type": "String"
+      }
+    },
+    "PubChem Reference": {
+      "Description": {
+        "value": "2. Material Types|[6,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[6,4]",
+        "type": "String"
+      }
+    },
+    "Abbreviation": {
+      "Description": {
+        "value": "2. Material Types|[7,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[7,4]",
+        "type": "String"
+      }
+    },
+    "Polymer constitutional unit (CU)": {
+      "Description": {
+        "value": "2. Material Types|[8,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[8,4]",
+        "type": "String"
+      }
+    },
+    "Polymer plastic type": {
+      "Description": {
+        "value": "2. Material Types|[9,1]",
+        "type": "List",
+        "validList": "Matrix::Polymer_plastic_type::Description"
+      },
+      "Note": {
+        "value": "2. Material Types|[9,4]",
+        "type": "String"
+      }
+    },
+    "Polymer class": {
+      "Description": {
+        "value": "2. Material Types|[10,1]",
+        "type": "List",
+        "validList": "Matrix::Polymer_class::Description"
+      },
+      "Note": {
+        "value": "2. Material Types|[10,4]",
+        "type": "String"
+      }
+    },
+    "Polymer type": {
+      "Description": {
+        "value": "2. Material Types|[11,1]",
+        "type": "List",
+        "validList": "Matrix::Polymer_type::Description"
+      },
+      "Note": {
+        "value": "2. Material Types|[11,4]",
+        "type": "String"
+      }
+    },
+    "Polymer manufacturer or source name": {
+      "Description": {
+        "value": "2. Material Types|[12,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[12,4]",
+        "type": "String"
+      }
+    },
+    "Polymer trade name": {
+      "Description": {
+        "value": "2. Material Types|[13,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[13,4]",
+        "type": "String"
+      }
+    },
+    "Polymer molecular weight": {
+      "Description": {
+        "value": "2. Material Types|[14,1]",
+        "type": "List",
+        "validList": "Matrix::Polymer_molecular_weight::Description"
+      },
+      "Value": {
+        "value": "2. Material Types|[14,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "2. Material Types|[14,3]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[14,4]",
+        "type": "String"
+      }
+    },
+    "Polydispersity": {
+      "Description": {
+        "value": "2. Material Types|[15,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[15,4]",
+        "type": "String"
+      }
+    },
+    "Tacticity": {
+      "Description": {
+        "value": "2. Material Types|[16,1]",
+        "type": "List",
+        "validList": "Matrix::Tacticity::Description"
+      },
+      "Note": {
+        "value": "2. Material Types|[16,4]",
+        "type": "String"
+      }
+    },
+    "Density": {
+      "Value": {
+        "value": "2. Material Types|[17,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "2. Material Types|[17,3]",
+        "type": "List",
+        "validList": "Matrix::Density::Unit"
+      },
+      "Note": {
+        "value": "2. Material Types|[17,4]",
+        "type": "String"
+      }
+    },
+    "Viscosity": {
+      "Value": {
+        "value": "2. Material Types|[18,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "2. Material Types|[18,3]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[18,4]",
+        "type": "String"
+      }
+    },
+    "Hardener": {
+      "Description": {
+        "value": "2. Material Types|[19,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[19,4]",
+        "type": "String"
+      }
+    },
+    "Additive": {
+      "Description": {
+        "value": "2. Material Types|[20,1]",
+        "type": "String"      
+      },
+      "Value": {
+        "value": "2. Material Types|[20,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "2. Material Types|[20,3]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[20,4]",
+        "type": "String"
+      }
+    },
+    "Matrix Component Composition weight fraction": {
+      "Description": {
+        "value": "2. Material Types|[21,1]",
+        "type": "String"      
+      },
+      "Value": {
+        "value": "2. Material Types|[21,2]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[21,4]",
+        "type": "String"
+      }
+    },
+    "Matrix Component Composition volume fraction": {
+      "Description": {
+        "value": "2. Material Types|[22,1]",
+        "type": "String"      
+      },
+      "Value": {
+        "value": "2. Material Types|[22,2]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[22,4]",
+        "type": "String"
+      }
+    }
+  },
+  "Filler": {
+    "Filler description": {
+      "Description": {
+        "value": "2. Material Types|[26,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[26,5]",
+        "type": "String"
+      }
+    },
+    "Filler chemical name/Filler name": {
+      "Description": {
+        "value": "2. Material Types|[27,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[27,5]",
+        "type": "String"
+      }
+    },
+    "Filler PubChem reference": {
+      "Description": {
+        "value": "2. Material Types|[28,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[28,5]",
+        "type": "String"
+      }
+    },
+    "Filler abbreviation": {
+      "Description": {
+        "value": "2. Material Types|[29,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[29,5]",
+        "type": "String"
+      }
+    },
+    "Manufacturer or source name": {
+      "Description": {
+        "value": "2. Material Types|[30,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[30,5]",
+        "type": "String"
+      }
+    },
+    "Trade name": {
+      "Description": {
+        "value": "2. Material Types|[31,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[31,5]",
+        "type": "String"
+      }
+    },
+    "Density": {
+      "Description": {
+        "value": "2. Material Types|[32,1]",
+        "type": "String"
+      },
+      "Value": {
+        "value": "2. Material Types|[32,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "2. Material Types|[32,3]",
+        "type": "List",
+        "validList": "Filler::Density::Unit"
+      },
+      "Note": {
+        "value": "2. Material Types|[32,5]",
+        "type": "String"
+      }
+    },
+    "Crystal phase": {
+      "Description": {
+        "value": "2. Material Types|[33,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[33,5]",
+        "type": "String"
+      }
+    },
+    "Particle diameter": {
+      "Description": {
+        "value": "2. Material Types|[34,1]",
+        "type": "String"
+      },
+      "Value": {
+        "value": "2. Material Types|[34,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "2. Material Types|[34,3]",
+        "type": "List",
+        "validList": "Filler::Particle_diameter::Unit"
+      },
+      "Standard Deviation": {
+        "value": "2. Material Types|[34,4]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[34,5]",
+        "type": "String"
+      }
+    },
+    "Specific surface area": {
+      "Description": {
+        "value": "2. Material Types|[35,1]",
+        "type": "String"
+      },
+      "Value": {
+        "value": "2. Material Types|[35,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "2. Material Types|[35,3]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[35,5]",
+        "type": "String"
+      }
+    },
+    "Total surface area": {
+      "Description": {
+        "value": "2. Material Types|[36,1]",
+        "type": "String"
+      },
+      "Value": {
+        "value": "2. Material Types|[36,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "2. Material Types|[36,3]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[36,5]",
+        "type": "String"
+      }
+    },
+    "Aspect ratio": {
+      "Description": {
+        "value": "2. Material Types|[37,1]",
+        "type": "String"
+      },
+      "Value": {
+        "value": "2. Material Types|[37,2]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[37,5]",
+        "type": "String"
+      }
+    },
+    "Non spherical shape-width": {
+      "Description": {
+        "value": "2. Material Types|[38,1]",
+        "type": "String"
+      },
+      "Value": {
+        "value": "2. Material Types|[38,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "2. Material Types|[38,3]",
+        "type": "List",
+        "validList": "Filler::Non_spherical_shape-width::Unit"
+      },
+      "Note": {
+        "value": "2. Material Types|[38,5]",
+        "type": "String"
+      }
+    },
+    "Non spherical shape-length": {
+      "Description": {
+        "value": "2. Material Types|[39,1]",
+        "type": "String"
+      },
+      "Value": {
+        "value": "2. Material Types|[39,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "2. Material Types|[39,3]",
+        "type": "List",
+        "validList": "Filler::Non_spherical_shape-length::Unit"
+      },
+      "Note": {
+        "value": "2. Material Types|[39,5]",
+        "type": "String"
+      }
+    },
+    "Non spherical shape-depth": {
+      "Description": {
+        "value": "2. Material Types|[40,1]",
+        "type": "String"
+      },
+      "Value": {
+        "value": "2. Material Types|[40,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "2. Material Types|[40,3]",
+        "type": "List",
+        "validList": "Filler::Non_spherical_shape-depth::Unit"
+      },
+      "Note": {
+        "value": "2. Material Types|[40,5]",
+        "type": "String"
+      }
+    },
+    "Filler Component Composition weight fraction": {
+      "Value": {
+        "value": "2. Material Types|[41,2]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[41,5]",
+        "type": "String"
+      }
+    },
+    "Filler Component Composition volume fraction": {
+      "Value": {
+        "value": "2. Material Types|[42,2]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[42,5]",
+        "type": "String"
+      }
+    }
+  },
+  "Filler Composition": {
+    "Fraction": {
+      "value": "2. Material Types|[45,1]",
+      "type": "List",
+      "validList": "Filler_Composition::Fraction"
+    }
+  },
+  "Particle Surface Treatment (PST) #": {
+    "PST chemical name": {
+      "Description": {
+        "value": "2. Material Types|[48,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[48,4]",
+        "type": "String"
+      }
+    },
+    "PST abbreviation": {
+      "Description": {
+        "value": "2. Material Types|[49,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[49,4]",
+        "type": "String"
+      }
+    },
+    "PST constitutional unit": {
+      "Description": {
+        "value": "2. Material Types|[50,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[50,4]",
+        "type": "String"
+      }
+    },
+    "PST manufacturer or source name": {
+      "Description": {
+        "value": "2. Material Types|[51,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[51,4]",
+        "type": "String"
+      }
+    },
+    "PST trade name": {
+      "Description": {
+        "value": "2. Material Types|[52,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[52,4]",
+        "type": "String"
+      }
+    },
+    "PST density": {
+      "Description": {
+        "value": "2. Material Types|[53,1]",
+        "type": "String"
+      },
+      "Value": {
+        "value": "2. Material Types|[53,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "2. Material Types|[53,3]",
+        "type": "List",
+        "validList": "Particle_Surface_Treatment::PST_density::Unit"
+      },
+      "Note": {
+        "value": "2. Material Types|[53,4]",
+        "type": "String"
+      }
+    },
+    "PST population density": {
+      "Description": {
+        "value": "2. Material Types|[54,1]",
+        "type": "String"
+      },
+      "Value": {
+        "value": "2. Material Types|[54,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "2. Material Types|[54,3]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[54,4]",
+        "type": "String"
+      }
+    },
+    "PST molecular weight": {
+      "Description": {
+        "value": "2. Material Types|[55,1]",
+        "type": "String"
+      },
+      "Value": {
+        "value": "2. Material Types|[55,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "2. Material Types|[55,3]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[55,4]",
+        "type": "String"
+      }
+    },
+    "PST Component Composition weight fraction": {
+      "Description": {
+        "value": "2. Material Types|[56,1]",
+        "type": "String"
+      },
+      "Value": {
+        "value": "2. Material Types|[56,2]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[56,4]",
+        "type": "String"
+      }
+    },
+    "PST Component Composition volumn fraction": {
+      "Description": {
+        "value": "2. Material Types|[57,1]",
+        "type": "String"
+      },
+      "Value": {
+        "value": "2. Material Types|[57,2]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "2. Material Types|[57,4]",
+        "type": "String"
+      }
+    }
+  },
+  "Surface Chemical Processing": {
+    "Additive #": {
+      "Additive - description": {
+        "Description/Fixed Value": {
+          "value": "2. Material Types|[62,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "2. Material Types|[62,3]",
+          "type": "String"
+        }
+      },
+      "Additive - additive": {
+        "Description/Fixed Value": {
+          "value": "2. Material Types|[63,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "2. Material Types|[63,3]",
+          "type": "String"
+        }
+      },
+      "Additive - amount": {
+        "Description/Fixed Value": {
+          "value": "2. Material Types|[64,1]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "2. Material Types|[64,2]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "2. Material Types|[64,3]",
+          "type": "String"
+        }
+      }
+    }
+  },
+  "Experimental Procedure": {
+    "value": "3. Synthesis and Processing|[2,1]",
+    "type": "String"
+  },
+  "Processing method #": {
+    "value": "3. Synthesis and Processing|[4,1]",
+    "type": "List",
+    "validList": "Synthesis_and_Processing::Processing_method"
+  },
+  "Solvent #": {
+    "Solvent - solvent name": {
+      "Description": {
+        "value":  "3. Synthesis and Processing|[7,1]",
+        "type": "String"
+      }
+    }
+  },
+  "Mixing #": {
+    "Mixing - method": {
+      "Description": {
+        "value":  "3. Synthesis and Processing|[10,1]",
+        "type": "List",
+        "validList": "Synthesis_and_Processing::Mixing::Mixing-method::Description"
+      }
+    }
+  },
+  "Extrusion": {
+    "Extrusion - type": {
+      "Description/Fixed Value": {
+        "value":  "3. Synthesis and Processing|[13,1]",
+        "type": "List",
+        "validList": "Synthesis_and_Processing::Extrusion::Extrusion-type::Description/Fixed_Value"
+      }
+    },
+    "Extrusion - temperature": {
+      "Description/Fixed Value": {
+        "value":  "3. Synthesis and Processing|[14,1]",
+        "type": "String"
+      },
+      "Unit": {
+        "value":  "3. Synthesis and Processing|[14,2]",
+        "type": "List",
+        "validList": "Synthesis_and_Processing::Extrusion::Extrusion-template::Unit"
+      }
+    }
+  },
+  "Heating #": {
+    "Heating - purpose": {
+      "Description/Fixed Value": {
+        "value":  "3. Synthesis and Processing|[17,1]",
+        "type": "List",
+        "validList": "Synthesis_and_Processing::Heating::Heating-purpose::Description/Fixed_Value"
+      }
+    },
+    "Heating - description": {
+      "Description/Fixed Value": {
+        "value":  "3. Synthesis and Processing|[18,1]",
+        "type": "String"
+      }
+    },
+    "Heating - temperature": {
+      "Description/Fixed Value": {
+        "value":  "3. Synthesis and Processing|[19,1]",
+        "type": "String"
+      },
+      "Unit": {
+        "value":  "3. Synthesis and Processing|[19,2]",
+        "type": "List",
+        "validList": "Synthesis_and_Processing::Heating::Heating-temperature::Unit"
+      }
+    },
+    "Heating - time": {
+      "Description/Fixed Value": {
+        "value":  "3. Synthesis and Processing|[20,1]",
+        "type": "String"
+      },
+      "Unit": {
+        "value":  "3. Synthesis and Processing|[20,2]",
+        "type": "List",
+        "validList": "Synthesis_and_Processing::Heating::Heating-time::Unit"
+      }
+    },
+    "Heating - pressure": {
+      "Description/Fixed Value": {
+        "value":  "3. Synthesis and Processing|[21,1]",
+        "type": "String"
+      },
+      "Unit": {
+        "value":  "3. Synthesis and Processing|[21,2]",
+        "type": "List",
+        "validList": "Synthesis_and_Processing::Heating::Heating-pressure::Unit"
+      }
+    },
+    "Heating - ambient condition": {
+      "Description/Fixed Value": {
+        "value":  "3. Synthesis and Processing|[22,1]",
+        "type": "List",
+        "validList": "Synthesis_and_Processing::Heating::Heating-ambient_condition::Description/Fixed_Value"
+      }
+    },
+    "Heating - molding mode": {
+      "Description/Fixed Value": {
+        "value":  "3. Synthesis and Processing|[23,1]",
+        "type": "List",
+        "validList": "Synthesis_and_Processing::Heating::Heating-molding_mode::Description/Fixed_Value"
+      }
+    },
+    "Other #": {
+      "Other - description": {
+        "Description": {
+          "value":  "3. Synthesis and Processing|[26,1]",
+          "type": "String"
+        }
+      }
+    }
+  },
+  "Microscopy": {
+    "Transmission electron microscopy": {
+      "Equipment used": {
+        "Description": {
+          "value": "4. Characterization Methods|[5,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[5,7]",
+          "type": "String"
+        }
+      },
+      "Equipment description": {
+        "Description": {
+          "value": "4. Characterization Methods|[6,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[6,7]",
+          "type": "String"
+        }
+      },
+      "Magnification": {
+        "Description": {
+          "value": "4. Characterization Methods|[7,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[7,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[7,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[7,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Microscopy::Transmission_electron_microscopy::Magnification::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[7,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[7,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[7,7]",
+          "type": "String"
+        }
+      },
+      "Accelerating voltage": {
+        "Description": {
+          "value": "4. Characterization Methods|[8,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[8,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[8,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[8,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Microscopy::Transmission_electron_microscopy::Accelerating_voltage::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[8,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[8,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[8,7]",
+          "type": "String"
+        }
+      },
+      "Emission current": {
+        "Description": {
+          "value": "4. Characterization Methods|[9,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[9,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[9,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[9,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Microscopy::Transmission_electron_microscopy::Emission_current::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[9,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[9,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[9,7]",
+          "type": "String"
+        }
+      },
+      "Working distance": {
+        "Description": {
+          "value": "4. Characterization Methods|[10,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[10,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[10,3]",
+          "type": "List",
+          "validList": "Characterization_Methods::Microscopy::Transmission_electron_microscopy::Working_distance::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[10,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Microscopy::Transmission_electron_microscopy::Working_distance::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[10,5]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[10,7]",
+          "type": "String"
+        }
+      },
+      "Exposure time": {
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[11,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[11,3]",
+          "type": "List",
+          "validList": "Characterization_Methods::Microscopy::Transmission_electron_microscopy::Exposure_time::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[11,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Microscopy::Transmission_electron_microscopy::Exposure_time::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[11,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[11,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[11,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Scanning electron microscopy": {
+      "Equipment used": {
+        "Description": {
+          "value": "4. Characterization Methods|[14,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[14,7]",
+          "type": "String"
+        }
+      },
+      "Equipment description": {
+        "Description": {
+          "value": "4. Characterization Methods|[15,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[15,7]",
+          "type": "String"
+        }
+      },
+      "Magnification": {
+        "Description": {
+          "value": "4. Characterization Methods|[16,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[16,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[16,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[16,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Microscopy::Scanning_electron_microscopy::Magnification::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[16,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[16,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[16,7]",
+          "type": "String"
+        }
+      },
+      "Accelerating voltage": {
+        "Description": {
+          "value": "4. Characterization Methods|[17,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[17,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[17,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[17,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Microscopy::Scanning_electron_microscopy::Accelerating_voltage::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[17,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[17,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[17,7]",
+          "type": "String"
+        }
+      },
+      "Emission current": {
+        "Description": {
+          "value": "4. Characterization Methods|[18,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[18,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[18,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[18,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Microscopy::Scanning_electron_microscopy::Emission_current::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[18,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[18,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[18,7]",
+          "type": "String"
+        }
+      },
+      "Working distance": {
+        "Description": {
+          "value": "4. Characterization Methods|[19,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[19,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[19,3]",
+          "type": "List",
+          "validList": "Characterization_Methods::Microscopy::Scanning_electron_microscopy::Working_distance::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[19,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Microscopy::Scanning_electron_microscopy::Working_distance::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[19,5]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[19,7]",
+          "type": "String"
+        }
+      },
+      "Exposure time": {
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[20,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[20,3]",
+          "type": "List",
+          "validList": "Characterization_Methods::Microscopy::Scanning_electron_microscopy::Exposure_time::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[20,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Microscopy::Scanning_electron_microscopy::Exposure_time::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[20,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[20,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[20,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Atomic force microscopy": {
+      "Equipment used": {
+        "Description": {
+          "value": "4. Characterization Methods|[23,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[23,7]",
+          "type": "String"
+        }
+      },
+      "Equipment description": {
+        "Description": {
+          "value": "4. Characterization Methods|[24,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[24,7]",
+          "type": "String"
+        }
+      },
+      "Result data": {
+        "Description": {
+          "value": "4. Characterization Methods|[25,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[25,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[25,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[25,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Microscopy::Atomic_force_microscopy::Result_data::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[25,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[25,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[25,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Optical microscopy": {
+      "Equipment used": {
+        "Description": {
+          "value": "4. Characterization Methods|[28,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[28,7]",
+          "type": "String"
+        }
+      },
+      "Equipment description": {
+        "Description": {
+          "value": "4. Characterization Methods|[29,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[29,7]",
+          "type": "String"
+        }
+      },
+      "Result data": {
+        "Description": {
+          "value": "4. Characterization Methods|[30,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[30,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[30,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[30,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Microscopy::Optical_microscopy::Result_data::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[30,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[30,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[30,7]",
+          "type": "String"
+        }
+      }
+    }
+  },
+  "Spectroscopy": {
+    "Fourier transform infrared spectroscopy": {
+      "Equipment used": {
+        "Description": {
+          "value": "4. Characterization Methods|[34,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[34,7]",
+          "type": "String"
+        }
+      },
+      "Equipment description": {
+        "Description": {
+          "value": "4. Characterization Methods|[35,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[35,7]",
+          "type": "String"
+        }
+      },
+      "Result data": {
+        "Description": {
+          "value": "4. Characterization Methods|[36,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[36,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[36,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[36,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Spectroscopy::Fourier_transform_infrared_spectroscopy::Result_data::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[36,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[36,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[36,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Dielectric and impedance spectroscopy analysis": {
+      "Equipment used": {
+        "Description": {
+          "value": "4. Characterization Methods|[39,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[39,7]",
+          "type": "String"
+        }
+      },
+      "Equipment description": {
+        "Description": {
+          "value": "4. Characterization Methods|[40,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[40,7]",
+          "type": "String"
+        }
+      },
+      "Result data": {
+        "Description": {
+          "value": "4. Characterization Methods|[41,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[41,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[41,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[41,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Spectroscopy::Dielectric_and_impedance_spectroscopy_analysis::Result_data::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[41,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[41,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[41,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Raman spectroscopy": {
+      "Equipment used": {
+        "Description": {
+          "value": "4. Characterization Methods|[44,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[44,7]",
+          "type": "String"
+        }
+      },
+      "Equipment description": {
+        "Description": {
+          "value": "4. Characterization Methods|[45,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[45,7]",
+          "type": "String"
+        }
+      },
+      "Result data (fixed value, unit)": {
+        "Description": {
+          "value": "4. Characterization Methods|[46,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[46,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[46,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[46,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Spectroscopy::Raman_spectroscopy::Result_data::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[46,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[46,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[46,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Xray photoelectron spectroscopy": {
+      "Equipment used": {
+        "Description": {
+          "value": "4. Characterization Methods|[49,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[49,7]",
+          "type": "String"
+        }
+      },
+      "Equipment description": {
+        "Description": {
+          "value": "4. Characterization Methods|[50,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[50,7]",
+          "type": "String"
+        }
+      },
+      "Result data (fixed value, unit)": {
+        "Description": {
+          "value": "4. Characterization Methods|[51,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[51,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[51,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[51,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Spectroscopy::Xray_photoelectron_spectroscopy::Result_data::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[51,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[51,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[51,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Nuclear magnetic resonance": {
+      "Equipment used": {
+        "Description": {
+          "value": "4. Characterization Methods|[54,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[54,7]",
+          "type": "String"
+        }
+      },
+      "Equipment description": {
+        "Description": {
+          "value": "4. Characterization Methods|[55,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[55,7]",
+          "type": "String"
+        }
+      },
+      "Result data (fixed value, unit)": {
+        "Description": {
+          "value": "4. Characterization Methods|[56,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[56,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[56,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[56,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Spectroscopy::Nuclear_magnetic_resonance::Result_data::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[56,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[56,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[56,7]",
+          "type": "String"
+        }
+      }
+    }
+  },
+  "Thermochemical": {
+    "Differential scanning calorimetry": {
+      "Equipment used": {
+        "Description": {
+          "value": "4. Characterization Methods|[60,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[60,7]",
+          "type": "String"
+        }
+      },
+      "Equipment description": {
+        "Description": {
+          "value": "4. Characterization Methods|[61,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[61,7]",
+          "type": "String"
+        }
+      },
+      "Heating rate": {
+        "Description": {
+          "value": "4. Characterization Methods|[62,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[62,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[62,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[62,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Thermochemical::Differential_scanning_calorimetry::Heating_rate::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[62,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[62,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[62,7]",
+          "type": "String"
+        }
+      },
+      "Cooling rate": {
+        "Description": {
+          "value": "4. Characterization Methods|[63,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[63,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[63,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[63,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Thermochemical::Differential_scanning_calorimetry::Cooling_rate::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[63,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[63,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[63,7]",
+          "type": "String"
+        }
+      },
+      "Cycle information": {
+        "Description": {
+          "value": "4. Characterization Methods|[64,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[64,7]",
+          "type": "String"
+        }
+      },
+      "Result data": {
+        "Description": {
+          "value": "4. Characterization Methods|[65,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[65,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[65,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[65,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Thermochemical::Differential_scanning_calorimetry::Result_data::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[65,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[65,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[65,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Thermogravimetric analysis": {
+      "Equipment used": {
+        "Description": {
+          "value": "4. Characterization Methods|[68,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[68,7]",
+          "type": "String"
+        }
+      },
+      "Equipment description": {
+        "Description": {
+          "value": "4. Characterization Methods|[69,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[69,7]",
+          "type": "String"
+        }
+      },
+      "Result data": {
+        "Description": {
+          "value": "4. Characterization Methods|[70,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[70,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[70,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[70,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Thermochemical::Thermogravimetric_analysis::Result_data::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[70,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[70,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[70,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Dynamic mechanical analysis": {
+      "Equipment used": {
+        "Description": {
+          "value": "4. Characterization Methods|[73,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[73,7]",
+          "type": "String"
+        }
+      },
+      "Equipment description": {
+        "Description": {
+          "value": "4. Characterization Methods|[74,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[74,7]",
+          "type": "String"
+        }
+      },
+      "Result data": {
+        "Description": {
+          "value": "4. Characterization Methods|[75,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[75,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[75,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[75,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Thermochemical::Dynamic_mechanical_analysis::Result_data::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[75,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[75,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[75,7]",
+          "type": "String"
+        }
+      }
+    }
+  },
+  "Scattering and diffraction": {
+    "Xray diffraction and scattering": {
+      "Equipment used": {
+        "Description": {
+          "value": "4. Characterization Methods|[79,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[79,7]",
+          "type": "String"
+        }
+      },
+      "Equipment description": {
+        "Description": {
+          "value": "4. Characterization Methods|[80,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[80,7]",
+          "type": "String"
+        }
+      },
+      "Result data": {
+        "Description": {
+          "value": "4. Characterization Methods|[81,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[81,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[81,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[81,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Scattering_and_diffraction::Xray_diffraction_and_scattering::Result_data::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[81,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[81,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[81,7]",
+          "type": "String"
+        }
+      }
+    }
+  },
+  "Others": {
+    "Pulsed electro acoustic": {
+      "Equipment used": {
+        "Description": {
+          "value": "4. Characterization Methods|[85,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[85,7]",
+          "type": "String"
+        }
+      },
+      "Equipment description": {
+        "Description": {
+          "value": "4. Characterization Methods|[86,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[86,7]",
+          "type": "String"
+        }
+      },
+      "Result data": {
+        "Description": {
+          "value": "4. Characterization Methods|[87,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[87,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[87,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[87,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Others::Pulsed_electro_acoustic::Result_data::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[87,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[87,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[87,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Rheometry": {
+      "Rheometer type": {
+        "Description": {
+          "value": "4. Characterization Methods|[90,1]",
+          "type": "List",
+          "validList": "Characterization_Methods::Others::Rheometry::Rheometer_type::Description"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[90,7]",
+          "type": "String"
+        }
+      },
+      "Equipment description": {
+        "Description": {
+          "value": "4. Characterization Methods|[91,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[91,7]",
+          "type": "String"
+        }
+      },
+      "Capillary size": {
+        "Description": {
+          "value": "4. Characterization Methods|[92,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[92,7]",
+          "type": "String"
+        }
+      },
+      "Result data": {
+        "Description": {
+          "value": "4. Characterization Methods|[93,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[93,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[93,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[93,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Others::Rheometry::Result_data::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[93,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[93,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[93,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Electrometry": {
+      "Equipment used": {
+        "Description": {
+          "value": "4. Characterization Methods|[96,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[96,7]",
+          "type": "String"
+        }
+      },
+      "Equipment description": {
+        "Description": {
+          "value": "4. Characterization Methods|[97,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[97,7]",
+          "type": "String"
+        }
+      },
+      "Result data": {
+        "Description": {
+          "value": "4. Characterization Methods|[98,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "4. Characterization Methods|[98,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "4. Characterization Methods|[98,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "4. Characterization Methods|[98,4]",
+          "type": "List",
+          "validList": "Characterization_Methods::Others::Electrometry::Result_data::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "4. Characterization Methods|[98,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "4. Characterization Methods|[98,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "4. Characterization Methods|[98,7]",
+          "type": "String"
+        }
+      }
+    }
+  },
+  "Mechanical": {
+    "Tensile": {
+      "Tensile Modulus": {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[5,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[5,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[5,3]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Tensile_Modulus::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[5,4]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Tensile_Modulus::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[5,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[5,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[5,7]",
+          "type": "String"
+        }
+      },
+      "Tensile stress at break": {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[6,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[6,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[6,3]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Tensile_stress_at_break::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[6,4]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Tensile_stress_at_break::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[6,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[6,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[6,7]",
+          "type": "String"
+        }
+      },
+      "Tensile stress at yield": {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[7,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[7,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[7,3]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Tensile_stress_at_yield::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[7,4]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Tensile_stress_at_yield::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[7,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[7,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[7,7]",
+          "type": "String"
+        }
+      },
+      "Tensile strength": {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[8,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[8,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[8,3]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Tensile_strength::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[8,4]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Tensile_strength::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[8,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[8,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[8,7]",
+          "type": "String"
+        }
+      },
+      "Tensile toughness": {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[9,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[9,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[9,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[9,4]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Tensile_Toughness::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[9,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[9,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[9,7]",
+          "type": "String"
+        }
+      },
+      "Strain at break" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[10,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[10,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[10,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[10,4]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Strain_at_break::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[10,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[10,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[10,7]",
+          "type": "String"
+        }
+      },
+      "Elongation at break" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[11,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[11,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[11,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[11,4]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Elongation_at_break::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[11,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[11,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[11,7]",
+          "type": "String"
+        }
+      },
+      "Elongation at yield" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[12,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[12,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[12,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[12,4]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Elongation_at_yield::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[12,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[12,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[12,7]",
+          "type": "String"
+        }
+      },
+      "Fiber tensile modulus" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[13,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[13,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[13,3]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Fiber_tensile_modulus::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[13,4]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Fiber_tensile_modulus::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[13,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[13,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[13,7]",
+          "type": "String"
+        }
+      },
+      "Fiber tensile strength" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[14,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[14,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[14,3]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Fiber_tensile_strength::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[14,4]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Fiber_tensile_strength::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[14,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[14,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[14,7]",
+          "type": "String"
+        }
+      },
+      "Fiber tensile elongation" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[15,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[15,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[15,3]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Fiber_tensile_elongation::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[15,4]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Fiber_tensile_elongation::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[15,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[15,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[15,7]",
+          "type": "String"
+        }
+      },
+      "Poisson's ratio" : {
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[16,2]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[16,7]",
+          "type": "String"
+        }
+      },
+      "Conditions-Strain rate" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[17,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[17,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[17,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[17,4]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Conditions-Strain_rate::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[17,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[17,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[17,7]",
+          "type": "String"
+        }
+      },
+      "Conditions-Preload" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[18,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[18,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[18,3]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Conditions-Preload::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[18,4]",
+          "type": "List",
+          "validList": "Mechanical::Tensile::Conditions-Preload::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[18,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[18,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[18,7]",
+          "type": "String"
+        }
+      },
+      "Stress relaxation (filename.xlsx)" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[19,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[19,7]",
+          "type": "String"
+        }
+      },
+      "Loading Profile (filename.xlsx)" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[20,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[20,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Flexural": {
+      "Flexural modulus":{
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[23,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[23,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[23,3]",
+          "type": "List",
+          "validList": "Mechanical::Flexural::Flexural_modulus::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[23,4]",
+          "type": "List",
+          "validList": "Mechanical::Flexural::Flexural_modulus::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[23,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[23,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[23,7]",
+          "type": "String"
+        }
+      },
+      "Flexural stress at break" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[24,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[24,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[24,3]",
+          "type": "List",
+          "validList": "Mechanical::Flexural::Flexural_stress_at_break::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[24,4]",
+          "type": "List",
+          "validList": "Mechanical::Flexural::Flexural_stress_at_break::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[24,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[24,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[24,7]",
+          "type": "String"
+        }
+      },
+      "Flexural stress at yield" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[25,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[25,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[25,3]",
+          "type": "List",
+          "validList": "Mechanical::Flexural::Flexural_stress_at_yield::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[25,4]",
+          "type": "List",
+          "validList": "Mechanical::Flexural::Flexural_stress_at_yield::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[25,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[25,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[25,7]",
+          "type": "String"
+        }
+      },
+      "Flexural toughness" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[26,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[26,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[26,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[26,4]",
+          "type": "List",
+          "validList": "Mechanical::Flexural::Flexural_Toughness::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[26,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[26,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[26,7]",
+          "type": "String"
+        }
+      },
+      "Conditions-Strain rate" : {
+          "Description": {
+          "value": "5.1 Properties-Mechanical|[27,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[27,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[27,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[27,4]",
+          "type": "List",
+          "validList": "Mechanical::Flexural::Conditions-Strain_rate::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[27,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[27,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[27,7]",
+          "type": "String"
+        }
+      },
+      "Conditions-Preload" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[28,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[28,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[28,3]",
+          "type": "List",
+          "validList": "Mechanical::Flexural::Conditions-Preload::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[28,4]",
+          "type": "List",
+          "validList": "Mechanical::Flexural::Conditions-Preload::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[28,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[28,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[28,7]",
+          "type": "String"
+        }
+      },
+      "Loading Profile (filename.xlsx)" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[29,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[29,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Compression": {
+      "Compression modulus":{
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[32,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[32,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[32,3]",
+          "type": "List",
+          "validList": "Mechanical::Compression::Compression_modulus::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[32,4]",
+          "type": "List",
+          "validList": "Mechanical::Compression::Compression_modulus::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[32,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[32,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[32,7]",
+          "type": "String"
+        }
+      },
+      "Compression stress at break" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[33,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[33,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[33,3]",
+          "type": "List",
+          "validList": "Mechanical::Compression::Compression_stress_at_break::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[33,4]",
+          "type": "List",
+          "validList": "Mechanical::Compression::Compression_stress_at_break::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[33,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[33,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[33,7]",
+          "type": "String"
+        }
+      },
+      "Compression stress at yield" : {
+          "Description": {
+          "value": "5.1 Properties-Mechanical|[34,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[34,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[34,3]",
+          "type": "List",
+          "validList": "Mechanical::Compression::Compression_stress_at_yield::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[34,4]",
+          "type": "List",
+          "validList": "Mechanical::Compression::Compression_stress_at_yield::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[34,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[34,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[34,7]",
+          "type": "String"
+        }
+      },
+      "Compressive toughness" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[35,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[35,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[35,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[35,4]",
+          "type": "List",
+          "validList": "Mechanical::Compression::Compressive_toughness::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[35,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[35,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[35,7]",
+          "type": "String"
+        }
+      },
+      "Conditions-Strain rate" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[36,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[36,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[36,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[36,4]",
+          "type": "List",
+          "validList": "Mechanical::Compression::Conditions-Strain_rate::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[36,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[36,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[36,7]",
+          "type": "String"
+        }
+      },
+      "Conditions-Preload" : {
+          "Description": {
+          "value": "5.1 Properties-Mechanical|[37,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[37,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[37,3]",
+          "type": "Mechanical::Compression::Conditions-Preload::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[37,4]",
+          "type": "Mechanical::Compression::Conditions-Preload::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[37,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[37,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[37,7]",
+          "type": "String"
+        }
+      },
+      "Loading Profile (filename.xlsx)" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[38,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[38,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Shear": {
+      "Shear modulus":{
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[41,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[41,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[41,3]",
+          "type": "List",
+          "validList": "Mechanical::Shear::Shear_modulus::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[41,4]",
+          "type": "List",
+          "validList": "Mechanical::Shear::Shear_modulus::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[41,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[41,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[41,7]",
+          "type": "String"
+        }
+      },
+      "Shear stress at break" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[42,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[42,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[42,3]",
+          "type": "List",
+          "validList": "Mechanical::Shear::Shear_stress_at_break::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[42,4]",
+          "type": "List",
+          "validList": "Mechanical::Shear::Shear_stress_at_break::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[42,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[42,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[42,7]",
+          "type": "String"
+        }
+      },
+      "Shear stress at yield" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[43,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[43,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[43,3]",
+          "type": "List",
+          "validList": "Mechanical::Shear::Shear_stress_at_yield::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[43,4]",
+          "type": "List",
+          "validList": "Mechanical::Shear::Shear_stress_at_yield::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[43,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[43,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[43,7]",
+          "type": "String"
+        }
+      },
+      "Conditions-Strain rate" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[44,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[44,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[44,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[44,4]",
+          "type": "List",
+          "validList": "Mechanical::Shear::Conditions-Strain_rate::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[44,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[44,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[44,7]",
+          "type": "String"
+        }
+      },
+      "Conditions-Preload" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[45,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[45,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[45,3]",
+          "type": "List",
+          "validList": "Mechanical::Shear::Conditions-Preload::Unit"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[45,4]",
+          "type": "List",
+          "validList": "Mechanical::Shear::Conditions-Preload::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[45,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[45,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[45,7]",
+          "type": "String"
+        }
+      },
+      "Loading Profile (filename.xlsx)" : {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[46,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[46,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Fracture": {
+      "Essential work of fracture (EWF)":{
+        "Pre-cracking process": {
+          "Description": {
+            "value": "5.1 Properties-Mechanical|[50,1]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.1 Properties-Mechanical|[50,7]",
+            "type": "String"
+          }
+        },
+        "Strain rate": {
+          "Description": {
+            "value": "5.1 Properties-Mechanical|[51,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.1 Properties-Mechanical|[51,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.1 Properties-Mechanical|[51,3]",
+            "type": "String"
+          },
+          "Uncertainty Type": {
+            "value": "5.1 Properties-Mechanical|[51,4]",
+            "type": "List",
+            "validList": "Mechanical::Fracture::Essential_work_of_fracture_(EWF)::Strain_rate::Uncertainty_type"
+          },
+          "Uncertainty Value": {
+            "value": "5.1 Properties-Mechanical|[51,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.1 Properties-Mechanical|[51,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.1 Properties-Mechanical|[51,7]",
+            "type": "String"
+          }
+        },
+        "Fracture energy": {
+          "Description": {
+            "value": "5.1 Properties-Mechanical|[52,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.1 Properties-Mechanical|[52,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.1 Properties-Mechanical|[52,3]",
+            "type": "String"
+          },
+          "Uncertainty Type": {
+            "value": "5.1 Properties-Mechanical|[52,4]",
+            "type": "List",
+            "validList": "Mechanical::Fracture::Essential_work_of_fracture_(EWF)::Fracture_energy::Uncertainty_type"
+          },
+          "Uncertainty Value": {
+            "value": "5.1 Properties-Mechanical|[52,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.1 Properties-Mechanical|[52,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.1 Properties-Mechanical|[52,7]",
+            "type": "String"
+          }
+        }
+      },
+      "Linear Elastic": {
+        "Sample shape": {
+          "Description": {
+            "value": "5.1 Properties-Mechanical|[55,1]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.1 Properties-Mechanical|[55,7]",
+            "type": "String"
+          }
+        },
+        "Pre-cracking process": {
+          "Description": {
+            "value": "5.1 Properties-Mechanical|[56,1]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.1 Properties-Mechanical|[56,7]",
+            "type": "String"
+          }
+        },
+        "Strain rate": {
+          "Description": {
+            "value": "5.1 Properties-Mechanical|[57,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.1 Properties-Mechanical|[57,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.1 Properties-Mechanical|[57,3]",
+            "type": "String"
+          },
+          "Uncertainty Type": {
+            "value": "5.1 Properties-Mechanical|[57,4]",
+            "type": "List",
+            "validList": "Mechanical::Fracture::Linear_Elastic::Strain_rate::Uncertainty_type"
+          },
+          "Uncertainty Value": {
+            "value": "5.1 Properties-Mechanical|[57,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.1 Properties-Mechanical|[57,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.1 Properties-Mechanical|[57,7]",
+            "type": "String"
+          }
+        },
+        "Fracture energy": {
+          "Description": {
+            "value": "5.1 Properties-Mechanical|[58,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.1 Properties-Mechanical|[58,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.1 Properties-Mechanical|[58,3]",
+            "type": "String"
+          },
+          "Uncertainty Type": {
+            "value": "5.1 Properties-Mechanical|[58,4]",
+            "type": "List",
+            "validList": "Mechanical::Fracture::Linear_Elastic::Fracture_energy::Uncertainty_type"
+          },
+          "Uncertainty Value": {
+            "value": "5.1 Properties-Mechanical|[58,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.1 Properties-Mechanical|[58,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.1 Properties-Mechanical|[58,7]",
+            "type": "String"
+          }
+        },
+        "K-factor": {
+          "Description": {
+            "value": "5.1 Properties-Mechanical|[59,1]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.1 Properties-Mechanical|[59,7]",
+            "type": "String"
+          }
+        },
+        "Loading Profile (filename.xlsx)": {
+          "Description": {
+            "value": "5.1 Properties-Mechanical|[60,1]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.1 Properties-Mechanical|[60,7]",
+            "type": "String"
+          }
+        }
+      },
+      "Plastic Elastic": {
+        "Sample shape": {
+          "Description": {
+            "value": "5.1 Properties-Mechanical|[63,1]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.1 Properties-Mechanical|[63,7]",
+            "type": "String"
+          }
+        },
+        "Pre-cracking process": {
+          "Description": {
+            "value": "5.1 Properties-Mechanical|[64,1]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.1 Properties-Mechanical|[64,7]",
+            "type": "String"
+          }
+        },
+        "Strain rate": {
+          "Description": {
+            "value": "5.1 Properties-Mechanical|[65,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.1 Properties-Mechanical|[65,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.1 Properties-Mechanical|[65,3]",
+            "type": "String"
+          },
+          "Uncertainty Type": {
+            "value": "5.1 Properties-Mechanical|[65,4]",
+            "type": "List",
+            "validList": "Mechanical::Fracture::Plastic_Elastic::Strain_rate::Uncertainty_type"
+          },
+          "Uncertainty Value": {
+            "value": "5.1 Properties-Mechanical|[65,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.1 Properties-Mechanical|[65,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.1 Properties-Mechanical|[65,7]",
+            "type": "String"
+          }
+        },
+        "Fracture energy": {
+          "Description": {
+            "value": "5.1 Properties-Mechanical|[66,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.1 Properties-Mechanical|[66,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.1 Properties-Mechanical|[66,3]",
+            "type": "String"
+          },
+          "Uncertainty Type": {
+            "value": "5.1 Properties-Mechanical|[66,4]",
+            "type": "List",
+            "validList": "Mechanical::Fracture::Plastic_Elastic::Fracture_energy::Uncertainty_type"
+          },
+          "Uncertainty Value": {
+            "value": "5.1 Properties-Mechanical|[66,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.1 Properties-Mechanical|[66,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.1 Properties-Mechanical|[66,7]",
+            "type": "String"
+          }
+        },
+        "J-integral": {
+          "Description": {
+            "value": "5.1 Properties-Mechanical|[67,1]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.1 Properties-Mechanical|[67,7]",
+            "type": "String"
+          }
+        },
+        "Loading Profile (filename.xlsx)": {
+          "Description": {
+            "value": "5.1 Properties-Mechanical|[68,1]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.1 Properties-Mechanical|[68,7]",
+            "type": "String"
+          }
+        }
+      }
+    },
+    "Impact": {
+      "Notch": {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[71,1]",
+          "type": "List",
+          "validList": "Mechanical::Impact::Notch::Description"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[71,7]",
+          "type": "String"
+        }
+      },
+      "IZOD-Area": {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[72,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[72,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[72,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[72,4]",
+          "type": "List",
+          "validList": "Mechanical::Impact::IZOD-Area::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[72,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[72,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[72,7]",
+          "type": "String"
+        }
+      },
+      "IZOD-Impact energy": {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[73,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[73,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[73,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[73,4]",
+          "type": "List",
+          "validList": "Mechanical::Impact::IZOD-Impact_energy::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[73,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[73,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[73,7]",
+          "type": "String"
+        }
+      },
+      "Charpy Impact Energy": {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[74,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[74,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[74,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[74,4]",
+          "type": "List",
+          "validList": "Mechanical::Impact::Charpy_Impact_Energy::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[74,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[74,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[74,7]",
+          "type": "String"
+        }
+      },
+      "Impact toughness": {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[75,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[75,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[75,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[75,4]",
+          "type": "List",
+          "validList": "Mechanical::Impact::Impact_toughness::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[75,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[75,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[75,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Hardness": {
+      "Test standard": {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[78,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[78,7]",
+          "type": "String"
+        }
+      },
+      "Scale": {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[79,1]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[79,7]",
+          "type": "String"
+        }
+      },
+      "Hardness value": {
+        "Description": {
+          "value": "5.1 Properties-Mechanical|[80,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.1 Properties-Mechanical|[80,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.1 Properties-Mechanical|[80,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.1 Properties-Mechanical|[80,4]",
+          "type": "List",
+          "validList": "Mechanical::Hardness::Hardness_value::Uncertainty_type"
+        },
+        "Uncertainty Value": {
+          "value": "5.1 Properties-Mechanical|[80,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.1 Properties-Mechanical|[80,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.1 Properties-Mechanical|[80,7]",
+          "type": "String"
+        }
+      }
+    }
+  },
+  "Viscoelastic": {
+    "Dynamic properties": {
+      "Equipment Description": {
+        "value": "5.2 Properties-Viscoelastic|[5,1]",
+        "type": "String"
+      },
+      "Measurement mode": {
+        "value": "5.2 Properties-Viscoelastic|[7,1]",
+        "type": "List",
+        "validList": "Viscoelastic::Dynamic_properties::Measurement_mode"
+      },
+      "Measurement method": {
+        "value": "5.2 Properties-Viscoelastic|[8,1]",
+        "type": "List",
+        "validList": "Viscoelastic::Dynamic_properties::Measurement_method"
+      },
+      "DMA mode": {
+        "value": "5.2 Properties-Viscoelastic|[10,1]",
+        "type": "List",
+        "validList": "Viscoelastic::Dynamic_properties::DMA_mode"
+      },
+      "DMA Test Conditions": {
+        "Temperature": {
+          "Description": {
+            "value": "5.2 Properties-Viscoelastic|[13,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.2 Properties-Viscoelastic|[13,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.2 Properties-Viscoelastic|[13,3]",
+            "type": "List",
+            "validList": "Viscoelastic::Dynamic_properties::DMA_Test_Conditions::Temperature::Unit"
+          },
+          "Note": {
+            "value": "5.2 Properties-Viscoelastic|[13,4]",
+            "type": "String"
+          }
+        },
+        "Strain amplitude": {
+          "Description": {
+            "value": "5.2 Properties-Viscoelastic|[14,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.2 Properties-Viscoelastic|[14,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.2 Properties-Viscoelastic|[14,3]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.2 Properties-Viscoelastic|[14,4]",
+            "type": "String"
+          }
+        },
+        "Frequency": {
+          "Description": {
+            "value": "5.2 Properties-Viscoelastic|[15,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.2 Properties-Viscoelastic|[15,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.2 Properties-Viscoelastic|[15,3]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.2 Properties-Viscoelastic|[15,4]",
+            "type": "String"
+          }
+        },
+        "DMA Datafile": [
+          {
+            "Description": {
+              "value": "5.2 Properties-Viscoelastic|[18,1]",
+              "type": "String"
+            },
+            "Datafile": {
+              "value": "5.2 Properties-Viscoelastic|[18,2]",
+              "type": "File"
+            },
+            "Note": {
+              "value": "5.2 Properties-Viscoelastic|[18,3]",
+              "type": "String"
+            }
+          },
+          {
+            "Description": {
+              "value": "5.2 Properties-Viscoelastic|[19,1]",
+              "type": "String"
+            },
+            "Datafile": {
+              "value": "5.2 Properties-Viscoelastic|[19,2]",
+              "type": "File"
+            },
+            "Note": {
+              "value": "5.2 Properties-Viscoelastic|[19,3]",
+              "type": "String"
+            }
+          }
+        ],
+        "Master Curve #": {
+          "Description": {
+            "value": "5.2 Properties-Viscoelastic|[20,1]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.2 Properties-Viscoelastic|[20,2]",
+            "type": "File"
+          },
+          "Note": {
+            "value": "5.2 Properties-Viscoelastic|[20,3]",
+            "type": "String"
+          }
+        }
+      }
+    },
+    "Creep" : {
+      "compressive": {
+        "Compressive creep rupture strength": {
+          "Description": {
+            "value": "5.2 Properties-Viscoelastic|[26,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.2 Properties-Viscoelastic|[26,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.2 Properties-Viscoelastic|[26,3]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::Compressive::Compressive_creep_rupture_strength::Unit"
+          },
+          "Uncertainty Type": {
+            "value": "5.2 Properties-Viscoelastic|[26,4]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::compressive::Compressive_creep_rupture_strength::Uncertainty_Type"
+          },
+          "Uncertainty Value": {
+            "value": "5.2 Properties-Viscoelastic|[26,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.2 Properties-Viscoelastic|[26,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.2 Properties-Viscoelastic|[26,7]",
+            "type": "String"
+          }
+        },
+        "Compressive creep rupture time": {
+          "Fixed Value": {
+            "value": "5.2 Properties-Viscoelastic|[27,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.2 Properties-Viscoelastic|[27,3]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::compressive::Compressive_creep_rupture_time::Unit"
+          },
+          "Uncertainty Type": {
+            "value": "5.2 Properties-Viscoelastic|[27,4]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::compressive::Compressive_creep_rupture_time::Uncertainty_Type"
+          },
+          "Uncertainty Value": {
+            "value": "5.2 Properties-Viscoelastic|[27,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.2 Properties-Viscoelastic|[27,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.2 Properties-Viscoelastic|[27,7]",
+            "type": "String"
+          }
+        },
+        "Compressive creep strain": {
+          "Description": {
+            "value": "5.2 Properties-Viscoelastic|[28,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.2 Properties-Viscoelastic|[28,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.2 Properties-Viscoelastic|[28,3]",
+            "type": "String"
+          },
+          "Uncertainty Type": {
+            "value": "5.2 Properties-Viscoelastic|[28,4]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::compressive::Compressive_creep_strain::Uncertainty_Type"
+          },
+          "Uncertainty Value": {
+            "value": "5.2 Properties-Viscoelastic|[28,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.2 Properties-Viscoelastic|[28,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.2 Properties-Viscoelastic|[28,7]",
+            "type": "String"
+          }
+        }
+      },
+      "Tensile": {
+        "Tensile creep recovery": {
+          "Description": {
+            "value": "5.2 Properties-Viscoelastic|[31,1]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.2 Properties-Viscoelastic|[31,7]",
+            "type": "String"
+          }
+        },
+        "Tensile creep modulus": {
+          "Description": {
+            "value": "5.2 Properties-Viscoelastic|[32,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.2 Properties-Viscoelastic|[32,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.2 Properties-Viscoelastic|[32,3]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::Tensile::Tensile_creep_modulus::Unit"
+          },
+          "Uncertainty Type": {
+            "value": "5.2 Properties-Viscoelastic|[32,4]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::Tensile::Tensile_creep_modulus::Uncertainty_Type"
+          },
+          "Uncertainty Value": {
+            "value": "5.2 Properties-Viscoelastic|[32,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.2 Properties-Viscoelastic|[32,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.2 Properties-Viscoelastic|[32,7]",
+            "type": "String"
+          }
+        },
+        "Tensile creep compliance": {
+          "Description": {
+            "value": "5.2 Properties-Viscoelastic|[33,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.2 Properties-Viscoelastic|[33,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.2 Properties-Viscoelastic|[33,3]",
+            "type": "String"
+          },
+          "Uncertainty Type": {
+            "value": "5.2 Properties-Viscoelastic|[33,4]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::Tensile::Tensile_creep_compliance::Uncertainty_Type"
+          },
+          "Uncertainty Value": {
+            "value": "5.2 Properties-Viscoelastic|[33,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.2 Properties-Viscoelastic|[33,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.2 Properties-Viscoelastic|[33,7]",
+            "type": "String"
+          }
+        },
+        "Tensile creep rupture strength": {
+          "Description": {
+            "value": "5.2 Properties-Viscoelastic|[34,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.2 Properties-Viscoelastic|[34,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.2 Properties-Viscoelastic|[34,3]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::Tensile::Tensile_creep_rupture_strength::Unit"
+          },
+          "Uncertainty Type": {
+            "value": "5.2 Properties-Viscoelastic|[34,4]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::Tensile::Tensile_creep_rupture_strength::Uncertainty_Type"
+          },
+          "Uncertainty Value": {
+            "value": "5.2 Properties-Viscoelastic|[34,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.2 Properties-Viscoelastic|[34,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.2 Properties-Viscoelastic|[34,7]",
+            "type": "String"
+          }
+        },
+        "Tensile creep rupture time": {
+          "Fixed Value": {
+            "value": "5.2 Properties-Viscoelastic|[35,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.2 Properties-Viscoelastic|[35,3]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::Tensile::Tensile_creep_rupture_time::Unit"
+          },
+          "Uncertainty Type": {
+            "value": "5.2 Properties-Viscoelastic|[35,4]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::Tensile::Tensile_creep_rupture_time::Uncertainty_Type"
+          },
+          "Uncertainty Value": {
+            "value": "5.2 Properties-Viscoelastic|[35,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.2 Properties-Viscoelastic|[35,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.2 Properties-Viscoelastic|[35,7]",
+            "type": "String"
+          }
+        },
+        "Tensile creep strain": {
+          "Description": {
+            "value": "5.2 Properties-Viscoelastic|[36,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.2 Properties-Viscoelastic|[36,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.2 Properties-Viscoelastic|[36,3]",
+            "type": "String"
+          },
+          "Uncertainty Type": {
+            "value": "5.2 Properties-Viscoelastic|[36,4]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::Tensile::Tensile_creep_strain::Uncertainty_Type"
+          },
+          "Uncertainty Value": {
+            "value": "5.2 Properties-Viscoelastic|[36,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.2 Properties-Viscoelastic|[36,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.2 Properties-Viscoelastic|[36,7]",
+            "type": "String"
+          }
+        }
+      },
+      "Flexural": {
+        "Flexural creep rupture strength": {
+          "Description": {
+            "value": "5.2 Properties-Viscoelastic|[39,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.2 Properties-Viscoelastic|[39,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.2 Properties-Viscoelastic|[39,3]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::Flexural::Flexural_creep_rupture_strength::Unit"
+          },
+          "Uncertainty Type": {
+            "value": "5.2 Properties-Viscoelastic|[39,4]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::Flexural::Flexural_creep_rupture_strength::Uncertainty_Type"
+          },
+          "Uncertainty Value": {
+            "value": "5.2 Properties-Viscoelastic|[39,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.2 Properties-Viscoelastic|[39,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.2 Properties-Viscoelastic|[39,7]",
+            "type": "String"
+          }
+        },
+        "Flexural creep rupture time": {
+          "Fixed Value": {
+            "value": "5.2 Properties-Viscoelastic|[40,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.2 Properties-Viscoelastic|[40,3]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::Flexural::Flexural_creep_rupture_time::Unit"
+          },
+          "Uncertainty Type": {
+            "value": "5.2 Properties-Viscoelastic|[40,4]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::Flexural::Flexural_creep_rupture_time::Uncertainty_Type"
+          },
+          "Uncertainty Value": {
+            "value": "5.2 Properties-Viscoelastic|[40,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.2 Properties-Viscoelastic|[40,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.2 Properties-Viscoelastic|[40,7]",
+            "type": "String"
+          }
+        },
+        "Flexural creep strain": {
+          "Description": {
+            "value": "5.2 Properties-Viscoelastic|[41,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value": "5.2 Properties-Viscoelastic|[41,2]",
+            "type": "String"
+          },
+          "Unit": {
+            "value": "5.2 Properties-Viscoelastic|[41,3]",
+            "type": "String"
+          },
+          "Uncertainty Type": {
+            "value": "5.2 Properties-Viscoelastic|[41,4]",
+            "type": "List",
+            "validList": "Viscoelastic::Creep::Flexural::Flexural_creep_strain::Uncertainty_Type"
+          },
+          "Uncertainty Value": {
+            "value": "5.2 Properties-Viscoelastic|[41,5]",
+            "type": "String"
+          },
+          "Datafile": {
+            "value": "5.2 Properties-Viscoelastic|[41,6]",
+            "type": "String"
+          },
+          "Note": {
+            "value": "5.2 Properties-Viscoelastic|[41,7]",
+            "type": "String"
+          }
+        }
+      }
+    }
+  },
+  "Electrical": {
+    "Conductivity": {
+      "Description/Condition": {
+        "value": "5.3 Properties-Electrical|[4,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[4,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[4,3]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.3 Properties-Electrical|[4,4]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[4,5]",
+        "type": "String"
+      }
+    },
+    "Current density": {
+      "Description/Condition": {
+        "value": "5.3 Properties-Electrical|[5,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[5,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[5,3]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.3 Properties-Electrical|[5,4]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[5,5]",
+        "type": "String"
+      }
+    },
+    "Energy density": {
+      "Description/Condition": {
+        "value": "5.3 Properties-Electrical|[6,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[6,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[6,3]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.3 Properties-Electrical|[6,4]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[6,5]",
+        "type": "String"
+      }
+    },
+    "Surface resistivity": {
+      "Description/Condition": {
+        "value": "5.3 Properties-Electrical|[7,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[7,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[7,3]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.3 Properties-Electrical|[7,4]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[7,5]",
+        "type": "String"
+      }
+    },
+    "Volume resistivity": {
+      "Description/Condition": {
+        "value": "5.3 Properties-Electrical|[8,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[8,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[8,3]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.3 Properties-Electrical|[8,4]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[8,5]",
+        "type": "String"
+      }
+    },
+    "Arc resistance" : {
+      "Description/Condition": {
+        "value": "5.3 Properties-Electrical|[9,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[9,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[9,3]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.3 Properties-Electrical|[9,4]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[9,5]",
+        "type": "String"
+      }
+    },
+    "Impedance" : {
+      "Description/Condition": {
+        "value": "5.3 Properties-Electrical|[10,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[10,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[10,3]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.3 Properties-Electrical|[10,4]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[10,5]",
+        "type": "String"
+      }
+    },
+    "Percolation threshold" : {
+      "Description/Condition": {
+        "value": "5.3 Properties-Electrical|[11,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[11,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[11,3]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.3 Properties-Electrical|[11,4]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[11,5]",
+        "type": "String"
+      }
+    },
+    "DC dielectric constant" : {
+      "Description/Condition": {
+        "value": "5.3 Properties-Electrical|[12,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[12,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[12,3]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.3 Properties-Electrical|[12,4]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[12,5]",
+        "type": "String"
+      }
+    }
+  },
+  "AC dielectric dispersion #": {
+    "Description":{
+      "Description/Condition": {
+        "value": "5.3 Properties-Electrical|[15,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[15,5]",
+        "type": "String"
+      }
+    },
+    "Dependence": {
+      "Description/Condition": {
+        "value": "5.3 Properties-Electrical|[16,1]",
+        "type": "List",
+        "validList": "AC_dielectric_dispersion_#::Dependence::Description/Condition"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[16,5]",
+        "type": "String"
+      }
+    },
+    "Test Conditions - Temperature" : {
+      "Description/Condition": {
+        "value": "5.3 Properties-Electrical|[17,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[17,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[17,3]",
+        "type": "List",
+        "validList": "AC_dielectric_dispersion_#::Test_Conditions_-_Temperature::Unit"
+      },
+      "Datafile": {
+        "value": "5.3 Properties-Electrical|[17,4]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[17,5]",
+        "type": "String"
+      }
+    },
+    "Test Conditions - Frequency" : {
+      "Description/Condition": {
+        "value": "5.3 Properties-Electrical|[18,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[18,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[18,3]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.3 Properties-Electrical|[18,4]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[18,5]",
+        "type": "String"
+      }
+    },
+    "Real permittivity": {
+      "Description/Condition": {
+        "value": "5.3 Properties-Electrical|[19,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[19,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[19,3]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.3 Properties-Electrical|[19,4]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[19,5]",
+        "type": "String"
+      }
+    },
+    "Loss permittivity" : {
+      "Description/Condition": {
+        "value": "5.3 Properties-Electrical|[20,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[20,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[20,3]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.3 Properties-Electrical|[20,4]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[20,5]",
+        "type": "String"
+      }
+    },
+    "Loss tangent" : {
+      "Description/Condition": {
+        "value": "5.3 Properties-Electrical|[21,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[21,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[21,3]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.3 Properties-Electrical|[21,4]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[21,5]",
+        "type": "String"
+    }
+    },
+    "Dielectric breakdown strength":{
+      "Condition": {
+        "value": "5.3 Properties-Electrical|[24,1]",
+        "type": "List",
+        "validList": "AC_dielectric_dispersion_#::Dielectric_breakdown_strength::Condition"
+      },
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[24,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[24,3]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.3 Properties-Electrical|[24,4]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[24,5]",
+        "type": "String"
+      }
+    },
+    "Weibull plot" : {
+      "Description": {
+        "value": "5.3 Properties-Electrical|[26,1]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.3 Properties-Electrical|[26,2]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[26,3]",
+        "type": "String"
+      }
+    },
+    "Weibull parameter - scale #" : {
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[29,1]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[29,2]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[29,3]",
+        "type": "String"
+      }
+    },
+    "Weibull parameter - shape #" : {
+      "Fixed Value": {
+        "value": "5.3 Properties-Electrical|[29,1]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.3 Properties-Electrical|[29,2]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.3 Properties-Electrical|[29,3]",
+        "type": "String"
+      }
+    }
+  },
+  "Thermal": {
+    "DSC profile #": {
+      "Datafile": {
+        "value": "5.4 Properties-Thermal|[5,1]",
+        "type": "String"
+      }
+    },
+    "Measurement Method": {
+      "Description": {
+        "value": "5.4 Properties-Thermal|[8,1]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.4 Properties-Thermal|[8,7]",
+        "type": "String"
+      }
+    },
+    "Crystallinity" : {
+      "Degree of crystallization": {
+        "Description": {
+          "value": "5.4 Properties-Thermal|[11,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.4 Properties-Thermal|[11,2]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.4 Properties-Thermal|[11,7]",
+          "type": "String"
+        }
+      },
+      "Growth rate of crystal": {
+        "Description": {
+          "value": "5.4 Properties-Thermal|[12,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.4 Properties-Thermal|[12,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.4 Properties-Thermal|[12,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.4 Properties-Thermal|[12,4]",
+          "type": "List",
+          "validList": "Thermal::Crystallinity::Growth_rate_of_crystal::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "5.4 Properties-Thermal|[12,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.4 Properties-Thermal|[12,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.4 Properties-Thermal|[12,7]",
+          "type": "String"
+        }
+      },
+      "Growth rate parameter of Avrami Equation": {
+        "Description": {
+          "value": "5.4 Properties-Thermal|[13,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.4 Properties-Thermal|[13,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.4 Properties-Thermal|[13,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.4 Properties-Thermal|[13,4]",
+          "type": "List",
+          "validList": "Thermal::Crystallinity::Growth_rate_parameter_of_Avrami_Equation::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "5.4 Properties-Thermal|[13,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.4 Properties-Thermal|[13,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.4 Properties-Thermal|[13,7]",
+          "type": "String"
+        }
+      },
+      "Nucleation parameter of Avrami Equation": {
+        "Description": {
+          "value": "5.4 Properties-Thermal|[14,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.4 Properties-Thermal|[14,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.4 Properties-Thermal|[14,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.4 Properties-Thermal|[14,4]",
+          "type": "List",
+          "validList": "Thermal::Crystallinity::Nucleation_parameter_of_Avrami_Equation::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "5.4 Properties-Thermal|[14,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.4 Properties-Thermal|[14,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.4 Properties-Thermal|[14,7]",
+          "type": "String"
+        }
+      },
+      "Half life of crystallization": {
+        "Description": {
+          "value": "5.4 Properties-Thermal|[15,1]",
+          "type": "String"
+        },
+        "Fixed Value": {
+          "value": "5.4 Properties-Thermal|[15,2]",
+          "type": "String"
+        },
+        "Unit": {
+          "value": "5.4 Properties-Thermal|[15,3]",
+          "type": "String"
+        },
+        "Uncertainty Type": {
+          "value": "5.4 Properties-Thermal|[15,4]",
+          "type": "List",
+          "validList": "Thermal::Crystallinity::Half_life_of_crystallization::Uncertainty_Type"
+        },
+        "Uncertainty Value": {
+          "value": "5.4 Properties-Thermal|[15,5]",
+          "type": "String"
+        },
+        "Datafile": {
+          "value": "5.4 Properties-Thermal|[15,6]",
+          "type": "String"
+        },
+        "Note": {
+          "value": "5.4 Properties-Thermal|[15,7]",
+          "type": "String"
+        }
+      }
+    },
+    "Crystallization temperature": {
+      "Description": {
+        "value": "5.4 Properties-Thermal|[17,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.4 Properties-Thermal|[17,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.4 Properties-Thermal|[17,3]",
+        "type": "List",
+        "validList": "Thermal::Crystallization_temperature::Unit"
+      },
+      "Uncertainty Type": {
+        "value": "5.4 Properties-Thermal|[17,4]",
+        "type": "List",
+        "validList": "Thermal::Crystallization_temperature::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.4 Properties-Thermal|[17,5]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.4 Properties-Thermal|[17,6]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.4 Properties-Thermal|[17,7]",
+        "type": "String"
+      }
+    },
+    "Heat of crystallization": {
+      "Description": {
+        "value": "5.4 Properties-Thermal|[19,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.4 Properties-Thermal|[19,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.4 Properties-Thermal|[19,3]",
+        "type": "String"
+      },
+      "Uncertainty Type": {
+        "value": "5.4 Properties-Thermal|[19,4]",
+        "type": "List",
+        "validList": "Thermal::Heat_of_crystallization::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.4 Properties-Thermal|[19,5]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.4 Properties-Thermal|[19,6]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.4 Properties-Thermal|[19,7]",
+        "type": "String"
+      }
+    },
+    "Heat of fusion": {
+      "Description": {
+        "value": "5.4 Properties-Thermal|[21,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.4 Properties-Thermal|[21,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.4 Properties-Thermal|[21,3]",
+        "type": "String"
+      },
+      "Uncertainty Type": {
+        "value": "5.4 Properties-Thermal|[21,4]",
+        "type": "List",
+        "validList": "Thermal::Heat_of_fusion::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.4 Properties-Thermal|[21,5]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.4 Properties-Thermal|[21,6]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.4 Properties-Thermal|[21,7]",
+        "type": "String"
+      }
+    },
+    "Thermal decomposition temperature #": {
+      "Description": {
+        "value": "5.4 Properties-Thermal|[23,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.4 Properties-Thermal|[23,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.4 Properties-Thermal|[23,3]",
+        "type": "List",
+        "validList": "Thermal::Thermal_decomposition_temperature_#::Unit"
+      },
+      "Uncertainty Type": {
+        "value": "5.4 Properties-Thermal|[23,4]",
+        "type": "List",
+        "validList": "Thermal::Thermal_decomposition_temperature_#::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.4 Properties-Thermal|[23,5]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.4 Properties-Thermal|[23,6]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.4 Properties-Thermal|[23,7]",
+        "type": "String"
+      }
+    },
+    "Glass transition temperature #": {
+      "Description": {
+        "value": "5.4 Properties-Thermal|[25,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.4 Properties-Thermal|[25,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.4 Properties-Thermal|[25,3]",
+        "type": "List",
+        "validList": "Thermal::Glass_transition_temperature_#::Unit"
+      },
+      "Uncertainty Type": {
+        "value": "5.4 Properties-Thermal|[25,4]",
+        "type": "List",
+        "validList": "Thermal::Glass_transition_temperature_#::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.4 Properties-Thermal|[25,5]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.4 Properties-Thermal|[25,6]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.4 Properties-Thermal|[25,7]",
+        "type": "String"
+      }
+    },
+    "LC phase transition temperature": {
+      "Description": {
+        "value": "5.4 Properties-Thermal|[27,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.4 Properties-Thermal|[27,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.4 Properties-Thermal|[27,3]",
+        "type": "List",
+        "validList": "Thermal::LC_phase_transition_temperature::Unit"
+      },
+      "Uncertainty Type": {
+        "value": "5.4 Properties-Thermal|[27,4]",
+        "type": "List",
+        "validList": "Thermal::LC_phase_transition_temperature::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.4 Properties-Thermal|[27,5]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.4 Properties-Thermal|[27,6]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.4 Properties-Thermal|[27,7]",
+        "type": "String"
+      }
+    },
+    "Melting temperature": {
+      "Description": {
+        "value": "5.4 Properties-Thermal|[29,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.4 Properties-Thermal|[29,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.4 Properties-Thermal|[29,3]",
+        "type": "List",
+        "validList": "Thermal::Melting_temperature::Unit"
+      },
+      "Uncertainty Type": {
+        "value": "5.4 Properties-Thermal|[29,4]",
+        "type": "List",
+        "validList": "Thermal::Melting_temperature::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.4 Properties-Thermal|[29,5]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.4 Properties-Thermal|[29,6]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.4 Properties-Thermal|[29,7]",
+        "type": "String"
+      }
+    },
+    "Specific heat capacity, C_p": {
+      "Description": {
+        "value": "5.4 Properties-Thermal|[31,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.4 Properties-Thermal|[31,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.4 Properties-Thermal|[31,3]",
+        "type": "String"
+      },
+      "Uncertainty Type": {
+        "value": "5.4 Properties-Thermal|[31,4]",
+        "type": "List",
+        "validList": "Thermal::Specific_heat_capacity,_C_p::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.4 Properties-Thermal|[31,5]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.4 Properties-Thermal|[31,6]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.4 Properties-Thermal|[31,7]",
+        "type": "String"
+      }
+    },
+    "Specific heat capacity, C_v": {
+      "Description": {
+        "value": "5.4 Properties-Thermal|[33,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.4 Properties-Thermal|[33,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.4 Properties-Thermal|[33,3]",
+        "type": "String"
+      },
+      "Uncertainty Type": {
+        "value": "5.4 Properties-Thermal|[33,4]",
+        "type": "List",
+        "validList": "Thermal::Specific_heat_capacity,_C_v::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.4 Properties-Thermal|[33,5]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.4 Properties-Thermal|[33,6]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.4 Properties-Thermal|[33,7]",
+        "type": "String"
+      }
+    },
+    "Thermal conductivity": {
+      "Description": {
+        "value": "5.4 Properties-Thermal|[35,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.4 Properties-Thermal|[35,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.4 Properties-Thermal|[35,3]",
+        "type": "String"
+      },
+      "Uncertainty Type": {
+        "value": "5.4 Properties-Thermal|[35,4]",
+        "type": "List",
+        "validList": "Thermal::Thermal_conductivity::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.4 Properties-Thermal|[35,5]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.4 Properties-Thermal|[35,6]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.4 Properties-Thermal|[35,7]",
+        "type": "String"
+      }
+    },
+    "Thermal diffusivity": {
+      "Description": {
+        "value": "5.4 Properties-Thermal|[37,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.4 Properties-Thermal|[37,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.4 Properties-Thermal|[37,3]",
+        "type": "String"
+      },
+      "Uncertainty Type": {
+        "value": "5.4 Properties-Thermal|[37,4]",
+        "type": "List",
+        "validList": "Thermal::Thermal_diffusivity::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.4 Properties-Thermal|[37,5]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.4 Properties-Thermal|[37,6]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.4 Properties-Thermal|[37,7]",
+        "type": "String"
+      }
+    },
+    "Brittle temperature": {
+      "Description": {
+        "value": "5.4 Properties-Thermal|[39,1]",
+        "type": "String"
+      },
+      "Fixed Value": {
+        "value": "5.4 Properties-Thermal|[39,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.4 Properties-Thermal|[39,3]",
+        "type": "List",
+        "validList": "Thermal::Brittle_temperature::Uncertainty_Type"
+      },
+      "Uncertainty Type": {
+        "value": "5.4 Properties-Thermal|[39,4]",
+        "type": "List",
+        "validList": "Thermal::Brittle_temperature::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.4 Properties-Thermal|[39,5]",
+        "type": "String"
+      },
+      "Datafile": {
+        "value": "5.4 Properties-Thermal|[39,6]",
+        "type": "String"
+      },
+      "Note": {
+        "value": "5.4 Properties-Thermal|[39,7]",
+        "type": "String"
+      }
+    }
+  },
+  "Volumetric": {
+    "Weight loss": {
+      "Description": {
+        "value": "5.5 Properties-Volumetric|[4,1]",
+        "type":"String"
+      },
+      "Fixed Value":{
+        "value": "5.5 Properties-Volumetric|[4,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.5 Properties-Volumetric|[4,3]",
+        "type": "String"
+
+      },
+      "Uncertainty Type":{
+        "value": "5.5 Properties-Volumetric|[4,4]",
+        "type": "List",
+        "validList":"Volumetric::Weight_loss::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.5 Properties-Volumetric|[4,5]",
+        "type":"String"
+
+      },
+      "Datafile": {
+        "value": "5.5 Properties-Volumetric|[4,6]",
+        "type": "String" 
+      },
+      "Note": {
+        "value": "5.5 Properties-Volumetric|[4,7]",
+        "type": "String"
+      }
+    },
+    "Interfacial thickness": {
+      "Description": {
+        "value": "5.5 Properties-Volumetric|[5,1]",
+        "type":"String"
+      },
+      "Fixed Value":{
+        "value": "5.5 Properties-Volumetric|[5,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.5 Properties-Volumetric|[5,3]",
+        "type": "List",
+        "validList":"Volumetric::Interfacial_thickness::Unit"
+
+      },
+      "Uncertainty Type":{
+        "value": "5.5 Properties-Volumetric|[5,4]",
+        "type": "List",
+        "validList":"Volumetric::Interfacial_thickness::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.5 Properties-Volumetric|[5,5]",
+        "type":"String"
+      }, 
+      "Note": {
+        "value": "5.5 Properties-Volumetric|[5,7]",
+        "type": "String"
+      }
+    },
+    "Density":{
+      "Description": {
+        "value": "5.5 Properties-Volumetric|[6,1]",
+        "type":"String"
+      },
+      "Fixed Value":{
+        "value": "5.5 Properties-Volumetric|[6,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.5 Properties-Volumetric|[6,3]",
+        "type": "List",
+        "validList":"Volumetric::Density::Unit"
+
+      },
+      "Uncertainty Type":{
+        "value": "5.5 Properties-Volumetric|[6,4]",
+        "type": "List",
+        "validList":"Volumetric::Density::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.5 Properties-Volumetric|[6,5]",
+        "type":"String"
+
+      },
+      "Datafile": {
+        "value": "5.5 Properties-Volumetric|[6,6]",
+        "type": "String" 
+      },
+      "Note": {
+        "value": "5.5 Properties-Volumetric|[6,7]",
+        "type": "String"
+      }
+    },
+    "Linear expansion coefficient": {
+      "Description": {
+        "value": "5.5 Properties-Volumetric|[7,1]",
+        "type":"String"
+      },
+      "Fixed Value":{
+        "value": "5.5 Properties-Volumetric|[7,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.5 Properties-Volumetric|[7,3]",
+        "type": "String"
+
+      },
+      "Uncertainty Type":{
+        "value": "5.5 Properties-Volumetric|[7,4]",
+        "type": "List",
+        "validList":"Volumetric::Linear_expansion_coefficient::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.5 Properties-Volumetric|[7,5]",
+        "type":"String"
+
+      },
+      "Datafile": {
+        "value": "5.5 Properties-Volumetric|[7,6]",
+        "type": "String" 
+      },
+      "Note": {
+        "value": "5.5 Properties-Volumetric|[7,7]",
+        "type": "String"
+      }
+    },
+    "Volume expansion coefficient": {
+      "Description": {
+        "value": "5.5 Properties-Volumetric|[8,1]",
+        "type":"String"
+      },
+      "Fixed Value":{
+        "value": "5.5 Properties-Volumetric|[8,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.5 Properties-Volumetric|[8,3]",
+        "type": "String"
+
+      },
+      "Uncertainty Type":{
+        "value": "5.5 Properties-Volumetric|[8,4]",
+        "type": "List",
+        "validList":"Volumetric::Volume_expansion_coefficient::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.5 Properties-Volumetric|[8,5]",
+        "type":"String"
+
+      },
+      "Datafile": {
+        "value": "5.5 Properties-Volumetric|[8,6]",
+        "type": "String" 
+      },
+      "Note": {
+        "value": "5.5 Properties-Volumetric|[8,7]",
+        "type": "String"
+      }
+    },
+    "Surface tension": {
+      "Description": {
+        "value": "5.5 Properties-Volumetric|[9,1]",
+        "type":"String"
+      },
+      "Fixed Value":{
+        "value": "5.5 Properties-Volumetric|[9,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.5 Properties-Volumetric|[9,3]",
+        "type": "String"
+
+      },
+      "Uncertainty Type":{
+        "value": "5.5 Properties-Volumetric|[9,4]",
+        "type": "List",
+        "validList":"Volumetric::Surface_tension::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.5 Properties-Volumetric|[9,5]",
+        "type":"String"
+
+      },
+      "Datafile": {
+        "value": "5.5 Properties-Volumetric|[9,6]",
+        "type": "String" 
+      },
+      "Note": {
+        "value": "5.5 Properties-Volumetric|[9,7]",
+        "type": "String"
+      }
+    },
+    "Interfacial tension": {
+      "Description": {
+        "value": "5.5 Properties-Volumetric|[10,1]",
+        "type":"String"
+      },
+      "Fixed Value":{
+        "value": "5.5 Properties-Volumetric|[10,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.5 Properties-Volumetric|[10,3]",
+        "type": "String"
+
+      },
+      "Uncertainty Type":{
+        "value": "5.5 Properties-Volumetric|[10,4]",
+        "type": "List",
+        "validList":"Volumetric::Interfacial_tension::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.5 Properties-Volumetric|[10,5]",
+        "type":"String"
+
+      },
+      "Datafile": {
+        "value": "5.5 Properties-Volumetric|[10,6]",
+        "type": "String" 
+      },
+      "Note": {
+        "value": "5.5 Properties-Volumetric|[10,7]",
+        "type": "String"
+      }
+    },
+    "Water absorption": {
+      "Description": {
+        "value": "5.5 Properties-Volumetric|[11,1]",
+        "type":"String"
+      },
+      "Fixed Value":{
+        "value": "5.5 Properties-Volumetric|[11,2]",
+        "type": "String"
+      },
+      "Unit": {
+        "value": "5.5 Properties-Volumetric|[11,3]",
+        "type": "String"
+
+      },
+      "Uncertainty Type":{
+        "value": "5.5 Properties-Volumetric|[11,4]",
+        "type": "List",
+        "validList":"Volumetric::Water_absorption::Uncertainty_Type"
+      },
+      "Uncertainty Value": {
+        "value": "5.5 Properties-Volumetric|[11,5]",
+        "type":"String"
+
+      },
+      "Datafile": {
+        "value": "5.5 Properties-Volumetric|[11,6]",
+        "type": "String" 
+      },
+      "Note": {
+        "value": "5.5 Properties-Volumetric|[11,7]",
+        "type": "String"
+      }
+    }
+  },
+  "Rheological": {
+    "Complex Modulus #": {
+      "Rheometer mode" : {
+        "value": "5.6 Properties-Rheological|[5,1]",
+        "type": "List",
+        "validList":"Rheological::Complex_Modulus::Rheometer_mode"
+      }
+    },
+    "Rheometer Test Conditions": {
+      "Temperature":{
+        "Description":{
+          "value":"5.6 Properties-Rheological|[8,1]",
+          "type":"String"
+        },
+        "Fixed Value": {
+          "value":"5.6 Properties-Rheological|[8,2]",
+          "type":"String"
+        },
+        "Unit": {
+          "value":"5.6 Properties-Rheological|[8,3]",
+          "type": "List",
+          "validList":"Rheological::Rheometer_Test_Conditions::Temperature::Unit"
+        },
+        "Note": {
+          "value":"5.6 Properties-Rheological|[8,4]",
+          "type":"String"
+        }
+      },
+      "Strain amplitude":{
+        "Description":{
+          "value":"5.6 Properties-Rheological|[9,1]",
+          "type":"String"
+        },
+        "Fixed Value": {
+          "value":"5.6 Properties-Rheological|[9,2]",
+          "type":"String"
+        },
+        "Unit": {
+          "value":"5.6 Properties-Rheological|[9,3]",
+          "type":"String"
+        },
+        "Note": {
+          "value":"5.6 Properties-Rheological|[9,4]",
+          "type":"String"
+        }
+      },
+      "Frequency": {
+        "Description":{
+          "value":"5.6 Properties-Rheological|[10,1]",
+          "type":"String"
+        },
+        "Fixed Value": {
+          "value":"5.6 Properties-Rheological|[10,2]",
+          "type":"String"
+        },
+        "Unit": {
+          "value":"5.6 Properties-Rheological|[10,3]",
+          "type":"String"
+        },
+        "Note": {
+          "value":"5.6 Properties-Rheological|[10,4]",
+          "type":"String"
+        }
+      },
+      "Rheological G' Datafile": {
+        "Description":{
+          "value":"5.6 Properties-Rheological|[13,1]",
+          "type":"String"
+        },
+        "Datafile":{
+          "value":"5.6 Properties-Rheological|[13,2]",
+          "type":"String"
+        },
+        "Note": {
+          "value":"5.6 Properties-Rheological|[13,3]",
+          "type":"String"
+        }
+      },
+      "Rheological G'' Datafile": {
+        "Description":{
+          "value":"5.6 Properties-Rheological|[14,1]",
+          "type":"String"
+        },
+        "Datafile":{
+          "value":"5.6 Properties-Rheological|[14,2]",
+          "type":"String"
+        },
+        "Note": {
+          "value":"5.6 Properties-Rheological|[14,3]",
+          "type":"String"
+        }
+      },
+      "Rheological tan_delta Datafile": {
+        "Description":{
+          "value":"5.6 Properties-Rheological|[15,1]",
+          "type":"String"
+        },
+        "Datafile":{
+          "value":"5.6 Properties-Rheological|[15,2]",
+          "type":"String"
+        },
+        "Note": {
+          "value":"5.6 Properties-Rheological|[15,3]",
+          "type":"String"
+        }
+      },
+      "Master Curve #": {
+        "Description":{
+          "value":"5.6 Properties-Rheological|[16,1]",
+          "type":"String"
+        },
+        "Datafile":{
+          "value":"5.6 Properties-Rheological|[16,2]",
+          "type":"String"
+        },
+        "Note": {
+          "value":"5.6 Properties-Rheological|[16,3]",
+          "type":"String"
+        }
+      }
+    },
+    "Viscosity #":{
+      "Rheometer mode":{
+        "value": "5.6 Properties-Rheological|[19,1]",
+        "type": "List",
+        "validList":"Rheological::Viscosity::Rheometer_mode"
+      },
+      "Rheometer Test Conditions":{
+        "Temperature": {
+          "Description":{
+            "value":"5.6 Properties-Rheological|[22,1]",
+            "type":"String"
+          },
+          "Fixed Value": {
+            "value":"5.6 Properties-Rheological|[22,2]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"5.6 Properties-Rheological|[22,3]",
+            "type": "List",
+            "validList":"Rheological::Viscosity::Rheometer_Test_Conditions:Temperature::Unit"
+          },
+          "Note": {
+            "value":"5.6 Properties-Rheological|[22,4]",
+            "type":"String"
+          }
+        },
+        "Strain amplitude":{
+          "Description":{
+            "value":"5.6 Properties-Rheological|[23,1]",
+            "type":"String"
+          },
+          "Fixed Value": {
+            "value":"5.6 Properties-Rheological|[23,2]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"5.6 Properties-Rheological|[23,3]",
+            "type":"String"
+          },
+          "Note": {
+            "value":"5.6 Properties-Rheological|[23,4]",
+            "type":"String"
+          }
+        },
+        "Frequency": {
+          "Description":{
+            "value":"5.6 Properties-Rheological|[24,1]",
+            "type":"String"
+          },
+          "Fixed Value": {
+            "value":"5.6 Properties-Rheological|[24,2]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"5.6 Properties-Rheological|[24,3]",
+            "type":"String"
+          },
+          "Note": {
+            "value":"5.6 Properties-Rheological|[24,4]",
+            "type":"String"
+          }
+        },
+        "Dynamic viscosity": {
+            "Description":{
+              "value":"5.6 Properties-Rheological|[27,1]",
+              "type":"String"
+            },
+            "Fixed Value": {
+              "value":"5.6 Properties-Rheological|[27,2]",
+              "type":"String"
+            },
+            "Unit": {
+              "value":"5.6 Properties-Rheological|[27,3]",
+              "type":"String"
+            },
+            "Uncertainty Type": {
+              "value":"5.6 Properties-Rheological|[27,4]",
+              "type": "List",
+              "validList":"Rheological:Viscosity::Rheometer_Test_Conditions::Dynamic_viscosity::Uncertainty_Type "
+            },
+            "Uncertainty Value":{
+              "value":"5.6 Properties-Rheological|[27,5]",
+              "type":"String"
+            },
+            "Datafile":{
+              "value":"5.6 Properties-Rheological|[27,6]",
+              "type":"String"
+            },
+            "Note":{
+              "value":"5.6 Properties-Rheological|[27,7]",
+              "type":"String"
+            }
+        },
+        "Melt viscosity": {
+          "Description":{
+            "value":"5.6 Properties-Rheological|[28,1]",
+            "type": "String"
+          },
+          "Fixed Value": {
+            "value":"5.6 Properties-Rheological|[28,2]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"5.6 Properties-Rheological|[28,3]",
+            "type":"String"
+          },
+          "Uncertainty Type": {
+            "value":"5.6 Properties-Rheological|[28,4]",
+            "type": "List",
+            "validList":"Rheological:Viscosity::Rheometer_Test_Conditions::Melt_viscosity::Uncertainty_Type "
+          },
+          "Uncertainty Value": {
+            "value":"5.6 Properties-Rheological|[28,5]",
+            "type":"String"
+          },
+          "Datafile":{
+            "value":"5.6 Properties-Rheological|[28,6]",
+            "type":"String"
+          },
+          "Note": {
+            "value":"5.6 Properties-Rheological|[28,7]",
+            "type":"String"
+          }
+
+        } 
+      }
+    }
+  },
+  "Microstructure": [
+    {
+      "Imagefile #": {
+        "Microstructure filename":{
+          "Datafile name.jpg/png/tif/gif": {
+            "value":"6. Microstructure|[4,1]",
+            "type":"File",
+            "validTypes": ["jpg", "png", "gif"]
+          },
+          "Note": {
+            "value": "6. Microstructure|[4,2]",
+            "type": "String"
+          }    
+        },
+        "Description":{
+          "Datafile":{
+            "value": "6. Microstructure|[5,1]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[5,2]",
+            "type": "String"
+          }    
+        },
+        "Microscopy type": {
+          "Datafile":{
+            "value": "6. Microstructure|[6,1]",
+            "type": "List",
+            "validList":"Imagefile::Microscopy_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[6,2]",
+            "type": "String"
+          }    
+        },
+        "Image type":{
+          "Datafile":{
+            "value": "6. Microstructure|[7,1]",
+            "type": "List",
+            "validList":"Imagefile::Image_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[7,2]",
+            "type": "String"
+          }    
+        } 
+      },
+      "Image dimension": {
+        "Width": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[10,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[10,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[10,3]",
+            "type": "String"
+          }
+        },
+        "Height": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[11,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[11,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[11,3]",
+            "type": "String"
+          }
+        },
+        "Depth":{
+          "Fixed Value": {
+            "value":"6. Microstructure|[12,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[12,2]",
+            "type":"String",
+            "default": "bit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[12,3]",
+            "type": "String"
+          } 
+        },
+        "Preprocessing": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[13,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[13,2]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[13,3]",
+            "type": "String"
+          } 
+        }
+      },
+      "Sample experimental info": {
+        "Sample size": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[16,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[16,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_size::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[16,3]",
+            "type": "String"
+          } 
+        },
+        "Sample thickness" : {
+          "Fixed Value": {
+            "value":"6. Microstructure|[17,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[17,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_thickness::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[17,3]",
+            "type": "String"
+          } 
+        }
+      }
+    },
+    {
+      "Imagefile #": {
+        "Microstructure filename":{
+          "Datafile name.jpg/png/tif/gif":{
+            "value":"6. Microstructure|[20,1]",
+            "type": "File",
+            "validTypes": ["jpg", "png", "gif"]
+          },
+          "Note": {
+            "value": "6. Microstructure|[20,2]",
+            "type": "String"
+          }    
+        },
+        "Description":{
+          "Datafile":{
+            "value": "6. Microstructure|[21,1]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[21,2]",
+            "type": "String"
+          }    
+        },
+        "Microscopy type": {
+          "Datafile":{
+            "value": "6. Microstructure|[22,1]",
+            "type": "List",
+            "validList":"Imagefile::Microscopy_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[22,2]",
+            "type": "String"
+          }    
+        },
+        "Image type":{
+          "Datafile":{
+            "value": "6. Microstructure|[23,1]",
+            "type": "List",
+            "validList":"Imagefile::Image_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[23,2]",
+            "type": "String"
+          }    
+        } 
+      },
+      "Image dimension": {
+        "Width": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[26,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[26,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[26,3]",
+            "type": "String"
+          }
+        },
+        "Height": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[27,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[27,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[27,3]",
+            "type": "String"
+          }
+        },
+        "Depth":{
+          "Fixed Value": {
+            "value":"6. Microstructure|[28,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[28,2]",
+            "type":"String",
+            "default": "bit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[28,3]",
+            "type": "String"
+          } 
+        },
+        "Preprocessing": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[29,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[29,2]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[29,3]",
+            "type": "String"
+          } 
+        }
+      },
+      "Sample experimental info": {
+        "Sample size": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[32,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[32,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_size::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[32,3]",
+            "type": "String"
+          } 
+        },
+        "Sample thickness" : {
+          "Fixed Value": {
+            "value":"6. Microstructure|[33,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[33,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_thickness::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[33,3]",
+            "type": "String"
+          } 
+        }
+      }
+    },
+    {
+      "Imagefile #": {
+        "Microstructure filename":{
+          "Datafile name.jpg/png/tif/gif":{
+            "value":"6. Microstructure|[36,1]",
+            "type":"File",
+            "validTypes": ["jpg", "png", "gif"]
+          },
+          "Note": {
+            "value": "6. Microstructure|[36,2]",
+            "type": "String"
+          }    
+        },
+        "Description":{
+          "Datafile":{
+            "value": "6. Microstructure|[37,1]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[37,2]",
+            "type": "String"
+          }    
+        },
+        "Microscopy type": {
+          "Datafile":{
+            "value": "6. Microstructure|[38,1]",
+            "type": "List",
+            "validList":"Imagefile::Microscopy_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[38,2]",
+            "type": "String"
+          }    
+        },
+        "Image type":{
+          "Datafile":{
+            "value": "6. Microstructure|[39,1]",
+            "type": "List",
+            "validList":"Imagefile::Image_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[39,2]",
+            "type": "String"
+          }    
+        } 
+      },
+      "Image dimension": {
+        "Width": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[42,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[42,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[42,3]",
+            "type": "String"
+          }
+        },
+        "Height": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[43,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[43,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[43,3]",
+            "type": "String"
+          }
+        },
+        "Depth":{
+          "Fixed Value": {
+            "value":"6. Microstructure|[44,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[44,2]",
+            "type":"String",
+            "default": "bit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[44,3]",
+            "type": "String"
+          } 
+        },
+        "Preprocessing": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[45,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[45,2]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[45,3]",
+            "type": "String"
+          } 
+        }
+      },
+      "Sample experimental info": {
+        "Sample size": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[48,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[48,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_size::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[48,3]",
+            "type": "String"
+          } 
+        },
+        "Sample thickness" : {
+          "Fixed Value": {
+            "value":"6. Microstructure|[49,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[49,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_thickness::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[49,3]",
+            "type": "String"
+          } 
+        }
+      }
+    },
+    {
+      "Imagefile #": {
+        "Microstructure filename":{
+          "Datafile name.jpg/png/tif/gif":{
+            "value":"6. Microstructure|[52,1]",
+            "type":"File",
+            "validTypes": ["jpg", "png", "gif"]
+          },
+          "Note": {
+            "value": "6. Microstructure|[52,2]",
+            "type": "String"
+          }    
+        },
+        "Description":{
+          "Datafile":{
+            "value": "6. Microstructure|[53,1]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[53,2]",
+            "type": "String"
+          }    
+        },
+        "Microscopy type": {
+          "Datafile":{
+            "value": "6. Microstructure|[54,1]",
+            "type": "List",
+            "validList":"Imagefile::Microscopy_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[54,2]",
+            "type": "String"
+          }    
+        },
+        "Image type":{
+          "Datafile":{
+            "value": "6. Microstructure|55,1]",
+            "type": "List",
+            "validList":"Imagefile::Image_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[55,2]",
+            "type": "String"
+          }    
+        } 
+      },
+      "Image dimension": {
+        "Width": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[58,1]",
+            "type":"String"
+          },"Unit": {
+            "value": "6. Microstructure|[58,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[58,3]",
+            "type": "String"
+          }
+        },
+        "Height": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[59,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[59,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[59,3]",
+            "type": "String"
+          }
+        },
+        "Depth":{
+          "Fixed Value": {
+            "value":"6. Microstructure|[60,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[60,2]",
+            "type":"String",
+            "default": "bit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[60,3]",
+            "type": "String"
+          } 
+        },
+        "Preprocessing": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[61,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[10,2]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[61,3]",
+            "type": "String"
+          } 
+        }
+      },
+      "Sample experimental info": {
+        "Sample size": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[64,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[64,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_size::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[64,3]",
+            "type": "String"
+          } 
+        },
+        "Sample thickness" : {
+          "Fixed Value": {
+            "value":"6. Microstructure|[65,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[65,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_thickness::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[65,3]",
+            "type": "String"
+          } 
+        }
+      }
+    },
+    {
+      "Imagefile #": {
+        "Microstructure filename":{
+          "Datafile name.jpg/png/tif/gif":{
+            "value":"6. Microstructure|[68,1]",
+            "type":"File",
+            "validTypes": ["jpg", "png", "gif"]
+          },
+          "Note": {
+            "value": "6. Microstructure|[68,2]",
+            "type": "String"
+          }    
+        },
+        "Description":{
+          "Datafile":{
+            "value": "6. Microstructure|[69,1]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[69,2]",
+            "type": "String"
+          }    
+        },
+        "Microscopy type": {
+          "Datafile":{
+            "value": "6. Microstructure|[70,1]",
+            "type": "List",
+            "validList":"Imagefile::Microscopy_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[70,2]",
+            "type": "String"
+          }    
+        },
+        "Image type":{
+          "Datafile":{
+            "value": "6. Microstructure|[71,1]",
+            "type": "List",
+            "validList":"Imagefile::Image_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[71,2]",
+            "type": "String"
+          }    
+        } 
+      },
+      "Image dimension": {
+        "Width": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[74,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[74,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[74,3]",
+            "type": "String"
+          }
+        },
+        "Height": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[75,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[75,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[75,3]",
+            "type": "String"
+          }
+        },
+        "Depth":{
+          "Fixed Value": {
+            "value":"6. Microstructure|[76,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[76,2]",
+            "type":"String",
+            "default": "bit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[76,3]",
+            "type": "String"
+          } 
+        },
+        "Preprocessing": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[77,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[10,2]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[77,3]",
+            "type": "String"
+          } 
+        }
+      },
+      "Sample experimental info": {
+        "Sample size": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[80,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[80,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_size::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[80,3]",
+            "type": "String"
+          } 
+        },
+        "Sample thickness" : {
+          "Fixed Value": {
+            "value":"6. Microstructure|[81,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[81,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_thickness::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[81,3]",
+            "type": "String"
+          } 
+        }
+      }
+    },
+    {
+      "Imagefile #": {
+        "Microstructure filename":{
+          "Datafile name.jpg/png/tif/gif":{
+            "value":"6. Microstructure|[84,1]",
+            "type":"File",
+            "validTypes": ["jpg", "png", "gif"]
+          },
+          "Note": {
+            "value": "6. Microstructure|[84,2]",
+            "type": "String"
+          }    
+        },
+        "Description":{
+          "Datafile":{
+            "value": "6. Microstructure|[85,1]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[85,2]",
+            "type": "String"
+          }    
+        },
+        "Microscopy type": {
+          "Datafile":{
+            "value": "6. Microstructure|[86,1]",
+            "type": "List",
+            "validList":"Imagefile::Microscopy_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[86,2]",
+            "type": "String"
+          }    
+        },
+        "Image type":{
+          "Datafile":{
+            "value": "6. Microstructure|[87,1]",
+            "type": "List",
+            "validList":"Imagefile::Image_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[87,2]",
+            "type": "String"
+          }    
+        } 
+      },
+      "Image dimension": {
+        "Width": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[90,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[90,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[90,3]",
+            "type": "String"
+          }
+        },
+        "Height": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[91,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[91,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[91,3]",
+            "type": "String"
+          }
+        },
+        "Depth":{
+          "Fixed Value": {
+            "value":"6. Microstructure|[92,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[92,2]",
+            "type":"String",
+            "default": "bit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[92,3]",
+            "type": "String"
+          } 
+        },
+        "Preprocessing": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[93,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[10,2]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[93,3]",
+            "type": "String"
+          } 
+        }
+      },
+      "Sample experimental info": {
+        "Sample size": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[96,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[96,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_size::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[96,3]",
+            "type": "String"
+          } 
+        },
+        "Sample thickness" : {
+          "Fixed Value": {
+            "value":"6. Microstructure|[97,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[97,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_thickness::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[97,3]",
+            "type": "String"
+          } 
+        }
+      }
+    },
+    {
+      "Imagefile #": {
+        "Microstructure filename":{
+          "Datafile name.jpg/png/tif/gif":{
+            "value":"6. Microstructure|[100,1]",
+            "type":"File",
+            "validTypes": ["jpg", "png", "gif"]
+          },
+          "Note": {
+            "value": "6. Microstructure|[100,2]",
+            "type": "String"
+          }    
+        },
+        "Description":{
+          "Datafile":{
+            "value": "6. Microstructure|[101,1]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[101,2]",
+            "type": "String"
+          }    
+        },
+        "Microscopy type": {
+          "Datafile":{
+            "value": "6. Microstructure|[102,1]",
+            "type": "List",
+            "validList":"Imagefile::Microscopy_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[102,2]",
+            "type": "String"
+          }    
+        },
+        "Image type":{
+          "Datafile":{
+            "value": "6. Microstructure|[103,1]",
+            "type": "List",
+            "validList":"Imagefile::Image_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[103,2]",
+            "type": "String"
+          }    
+        } 
+      },
+      "Image dimension": {
+        "Width": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[106,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[106,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[106,3]",
+            "type": "String"
+          }
+        },
+        "Height": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[107,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[107,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[107,3]",
+            "type": "String"
+          }
+        },
+        "Depth":{
+          "Fixed Value": {
+            "value":"6. Microstructure|[108,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[108,2]",
+            "type":"String",
+            "default": "bit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[108,3]",
+            "type": "String"
+          } 
+        },
+        "Preprocessing": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[109,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[109,2]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[109,3]",
+            "type": "String"
+          } 
+        }
+      },
+      "Sample experimental info": {
+        "Sample size": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[112,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[112,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_size::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[112,3]",
+            "type": "String"
+          } 
+        },
+        "Sample thickness" : {
+          "Fixed Value": {
+            "value":"6. Microstructure|[113,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[113,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_thickness::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[113,3]",
+            "type": "String"
+          } 
+        }
+      }
+    },
+    {
+      "Imagefile #": {
+        "Microstructure filename":{
+          "Datafile name.jpg/png/tif/gif":{
+            "value":"6. Microstructure|[116,1]",
+            "type":"File",
+            "validTypes": ["jpg", "png", "gif"]
+          },
+          "Note": {
+            "value": "6. Microstructure|[116,2]",
+            "type": "String"
+          }    
+        },
+        "Description":{
+          "Datafile":{
+            "value": "6. Microstructure|[117,1]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[117,2]",
+            "type": "String"
+          }    
+        },
+        "Microscopy type": {
+          "Datafile":{
+            "value": "6. Microstructure|[118,1]",
+            "type": "List",
+            "validList":"Imagefile::Microscopy_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[118,2]",
+            "type": "String"
+          }    
+        },
+        "Image type":{
+          "Datafile":{
+            "value": "6. Microstructure|[119,1]",
+            "type": "List",
+            "validList":"Imagefile::Image_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[119,2]",
+            "type": "String"
+          }    
+        } 
+      },
+      "Image dimension": {
+        "Width": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[122,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[122,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[122,3]",
+            "type": "String"
+          }
+        },
+        "Height": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[123,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[123,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[123,3]",
+            "type": "String"
+          }
+        },
+        "Depth":{
+          "Fixed Value": {
+            "value":"6. Microstructure|[124,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[124,2]",
+            "type":"String",
+            "default": "bit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[124,3]",
+            "type": "String"
+          } 
+        },
+        "Preprocessing": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[125,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[125,2]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[125,3]",
+            "type": "String"
+          } 
+        }
+      },
+      "Sample experimental info": {
+        "Sample size": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[128,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[128,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_size::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[128,3]",
+            "type": "String"
+          } 
+        },
+        "Sample thickness" : {
+          "Fixed Value": {
+            "value":"6. Microstructure|[129,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[129,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_thickness::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[129,3]",
+            "type": "String"
+          } 
+        }
+      }
+    },
+    {
+      "Imagefile #": {
+        "Microstructure filename":{
+          "Datafile name.jpg/png/tif/gif":{
+            "value":"6. Microstructure|[132,1]",
+            "type":"File",
+            "validTypes": ["jpg", "png", "gif"]
+          },
+          "Note": {
+            "value": "6. Microstructure|[132,2]",
+            "type": "String"
+          }    
+        },
+        "Description":{
+          "Datafile":{
+            "value": "6. Microstructure|[133,1]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[133,2]",
+            "type": "String"
+          }    
+        },
+        "Microscopy type": {
+          "Datafile":{
+            "value": "6. Microstructure|[134,1]",
+            "type": "List",
+            "validList":"Imagefile::Microscopy_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[134,2]",
+            "type": "String"
+          }    
+        },
+        "Image type":{
+          "Datafile":{
+            "value": "6. Microstructure|[135,1]",
+            "type": "List",
+            "validList":"Imagefile::Image_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[135,2]",
+            "type": "String"
+          }    
+        } 
+      },
+      "Image dimension": {
+        "Width": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[138,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[138,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[138,3]",
+            "type": "String"
+          }
+        },
+        "Height": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[139,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[139,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[139,3]",
+            "type": "String"
+          }
+        },
+        "Depth":{
+          "Fixed Value": {
+            "value":"6. Microstructure|[140,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[140,2]",
+            "type":"String",
+            "default": "bit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[140,3]",
+            "type": "String"
+          } 
+        },
+        "Preprocessing": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[141,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[141,2]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[141,3]",
+            "type": "String"
+          } 
+        }
+      },
+      "Sample experimental info": {
+        "Sample size": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[144,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[144,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_size::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[144,3]",
+            "type": "String"
+          } 
+        },
+        "Sample thickness" : {
+          "Fixed Value": {
+            "value":"6. Microstructure|[145,1]",
+            "type": "String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[145,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_thickness::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[145,3]",
+            "type": "String"
+          } 
+        }
+      }
+    },
+    {
+      "Imagefile #": {
+        "Microstructure filename":{
+          "Datafile name.jpg/png/tif/gif":{
+            "value":"6. Microstructure|[148,1]",
+            "type":"File",
+            "validTypes": ["jpg", "png", "gif"]
+          },
+          "Note": {
+            "value": "6. Microstructure|[148,2]",
+            "type": "String"
+          }    
+        },
+        "Description":{
+          "Datafile":{
+            "value": "6. Microstructure|[149,1]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[149,2]",
+            "type": "String"
+          }    
+        },
+        "Microscopy type": {
+          "Datafile":{
+            "value": "6. Microstructure|[150,1]",
+            "type": "List",
+            "validList":"Imagefile::Microscopy_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[150,2]",
+            "type": "String"
+          }    
+        },
+        "Image type":{
+          "Datafile":{
+            "value": "6. Microstructure|[151,1]",
+            "type": "List",
+            "validList":"Imagefile::Image_type::Datafile"
+          },
+          "Note": {
+            "value": "6. Microstructure|[151,2]",
+            "type": "String"
+          }    
+        } 
+      },
+      "Image dimension": {
+        "Width": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[154,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[154,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[154,3]",
+            "type": "String"
+          }
+        },
+        "Height": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[155,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[155,2]",
+            "type":"String",
+            "default": "pixel"
+          },
+          "Note": {
+            "value": "6. Microstructure|[155,3]",
+            "type": "String"
+          }
+        },
+        "Depth":{
+          "Fixed Value": {
+            "value":"6. Microstructure|[156,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[156,2]",
+            "type":"String",
+            "default": "bit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[156,3]",
+            "type": "String"
+          } 
+        },
+        "Preprocessing": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[157,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value": "6. Microstructure|[157,2]",
+            "type":"String"
+          },
+          "Note": {
+            "value": "6. Microstructure|[157,3]",
+            "type": "String"
+          } 
+        }
+      },
+      "Sample experimental info": {
+        "Sample size": {
+          "Fixed Value": {
+            "value":"6. Microstructure|[160,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[160,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_size::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[160,3]",
+            "type": "String"
+          } 
+        },
+        "Sample thickness" : {
+          "Fixed Value": {
+            "value":"6. Microstructure|[161,1]",
+            "type":"String"
+          },
+          "Unit": {
+            "value":"6. Microstructure|[161,2]",
+            "type": "List",
+            "validList":"Sample_experimental_info::Sample_thickness::Unit"
+          },
+          "Note": {
+            "value": "6. Microstructure|[161,3]",
+            "type": "String"
+          } 
+        }
+      }
+    }
+  ]
+}

--- a/resfulservice/package.json
+++ b/resfulservice/package.json
@@ -38,6 +38,7 @@
         "unique-names-generator": "^4.7.1",
         "winston": "^3.5.1",
         "ws": "^8.7.0",
+        "xlsx": "^0.18.5",
         "xml-formatter": "^3.3.2"
     },
     "scripts": {

--- a/resfulservice/spec/controllers/curationController.spec.js
+++ b/resfulservice/spec/controllers/curationController.spec.js
@@ -1,0 +1,260 @@
+const chai = require('chai');
+const sinon = require('sinon');
+const { user, correctXlsxFile, wrontXlsxFile, mockCurationList, mockCuratedXlsxObject, fetchecdCuratedXlsxObject, mockSheetData, mockSheetData2, updatedCuratedXlsxObject, mockBaseObject, mockJsonStructure, mockCurationListMap, mockSheetData3, mockSheetData4, mockJsonStructure2, mockJsonStructure4, mockUploadedFiles } = require('../mocks')
+const XlsxObject = require('../../src/models/curatedObject');
+const XlsxCurationList = require('../../src/models/xlsxCurationList');
+const XlsxFileManager = require('../../src/utils/xlsxFileManager');
+const XlsxController = require('../../src/controllers/curationController');
+
+const { expect } = chai;
+
+describe('Xlsx Controllers Unit Tests:', function() {
+
+  afterEach(() => sinon.restore());
+
+  const req = { 
+    logger: { info: (_message) => { }, error: (_message) => { }, notice: (_message) =>  {} },
+    user,
+    files: {}
+  }
+
+  const res = {
+    status: () => {},
+    json: () => {},
+  };
+
+  const next = function (fn) {
+    return fn;
+  };
+
+  context('curateXlsxSpreadsheet', () => {
+    it('should return a 400 error if no file is uploaded', async function() {
+      const next = function (fn) {
+        return fn;
+      };
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(res, 'json').returnsThis();
+      const result = await XlsxController.curateXlsxSpreadsheet(req, res, next);
+
+      expect(result).to.have.property('message');
+      expect(result.message).to.equal('Material template files not uploaded', 'createXlsxObject');
+    });
+
+    it('should return a 400 error if material_template.xlsx file is not uploaded', async function() {
+      req.files.uploadfile = wrontXlsxFile
+      const next = function (fn) {
+        return fn;
+      };
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(res, 'json').returnsThis();
+      const result = await XlsxController.curateXlsxSpreadsheet(req, res, next);
+
+      expect(result).to.have.property('message');
+      expect(result.message).to.equal('Master template xlsx file not uploaded', 'createXlsxObject');
+    });
+
+    it('should return a 400 error if error is found while processing the parsing spreadsheet', async function() {
+      req.files.uploadfile = correctXlsxFile;
+      const next = function (fn) {
+        return fn;
+      };
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(res, 'json').returns({ errors: { Origin: 'invalid value' } });
+      sinon.stub(XlsxCurationList, 'find').returns(mockCurationList);
+      sinon.stub(XlsxController, 'createMaterialObject').returns( { count: 1, errors: { Origin: 'invalid value' }});
+      const result = await XlsxController.curateXlsxSpreadsheet(req, res, next);
+
+      expect(result).to.have.property('errors');
+    });
+
+    it('should curateXlsx object', async function() {
+      req.files.uploadfile = correctXlsxFile;
+      const next = function (fn) {
+        return fn;
+      };
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(res, 'json').returns(fetchecdCuratedXlsxObject);
+      sinon.stub(XlsxCurationList, 'find').returns(mockCurationList);
+      sinon.stub(XlsxController, 'createMaterialObject').returns(mockCuratedXlsxObject);
+      sinon.stub(XlsxObject.prototype, 'save').callsFake(() => (fetchecdCuratedXlsxObject))
+      const result = await XlsxController.curateXlsxSpreadsheet(req, res, next);
+
+      expect(result).to.have.property('object');
+      expect(result).to.have.property('user');
+    });
+
+    it('should return a 500 server error', async function() {
+      req.files.uploadfile = correctXlsxFile;
+      const nextSpy = sinon.spy();
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(res, 'json').returnsThis();
+      sinon.stub(XlsxCurationList, 'find').throws();
+
+      await XlsxController.curateXlsxSpreadsheet(req, res, nextSpy);
+      sinon.assert.calledOnce(nextSpy);
+    });
+  })
+
+  context('getXlsxCurations', () => {
+    it('should return 404 not found error', async () => {
+      req.query = { xlsxObjectId: 'a90w49a40ao4094k4aed'}
+      sinon.stub(XlsxObject, 'findOne').returns(null);
+      const result = await XlsxController.getXlsxCurations(req, res, next);
+      expect(result).to.have.property('message');
+      expect(result.message).to.equal('Xlsx Object not found');
+    })
+
+    it('should return an xlsx curation when an xlsxObjectId is provided', async () => {
+      req.query = { xlsxObjectId: 'a90w49a40ao4094k4aed'}
+      const next = function (fn) {
+        return fn;
+      };
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(res, 'json').returns(fetchecdCuratedXlsxObject);
+      sinon.stub(XlsxObject, 'findOne').returns(fetchecdCuratedXlsxObject);
+      
+      const result = await XlsxController.getXlsxCurations(req, res, next);
+
+      expect(result).to.be.an('Object');
+      expect(result).to.have.property('object');
+      expect(result).to.have.property('user');
+    });
+    it('should return an xlsx curation when an xlsxObjectId is provided and user is admin', async () => {
+      req.query = { xlsxObjectId: 'a90w49a40ao4094k4aed'};
+      req.user.roles = 'admin'
+      const next = function (fn) {
+        return fn;
+      };
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(res, 'json').returns(fetchecdCuratedXlsxObject);
+      sinon.stub(XlsxObject, 'findOne').returns(fetchecdCuratedXlsxObject);
+      
+      const result = await XlsxController.getXlsxCurations(req, res, next);
+
+      expect(result).to.be.an('Object');
+      expect(result).to.have.property('object');
+      expect(result).to.have.property('user');
+    })
+    it('should return a list of xlsx curations when an xlsxObjectId is not provided', async () => {
+      req.query = { xlsxObjectId: null }
+      const next = function (fn) {
+        return fn;
+      };
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(res, 'json').returns(Array(3).fill(fetchecdCuratedXlsxObject));
+      sinon.stub(XlsxObject, 'find').returns({ object: Array(3).fill(fetchecdCuratedXlsxObject), select: sinon.stub().returnsThis()});
+      
+      const result = await XlsxController.getXlsxCurations(req, res, next);
+      expect(result).to.be.an('Array');
+      expect(result[0]).to.have.property('object');
+      expect(result[0]).to.have.property('user');
+    })
+    it('should return a 500 server error', async function() {
+      req.query = { xlsxObjectId: 'a90w49a40ao4094k4aed'}
+      const nextSpy = sinon.spy();
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(res, 'json').returnsThis();
+      sinon.stub(XlsxObject, 'findOne').throws();
+
+      await XlsxController.getXlsxCurations(req, res, nextSpy);
+      sinon.assert.calledOnce(nextSpy);
+    });
+  });
+  context('updateXlsxCurations', () => {
+    it('should return 404 not found error', async () => {
+      req.body = { payload: mockCuratedXlsxObject }
+      req.params = { xlsxObjectId: 'a90w49a40ao4094k4aed'}
+      sinon.stub(XlsxObject, 'findOne').returns(null);
+      const result = await XlsxController.updateXlsxCurations(req, res, next);
+      expect(result).to.have.property('message');
+      expect(result.message).to.equal('Xlsx Object not found');
+    });
+    it('should return a message "No changes"', async () => {
+      req.body = { payload: mockBaseObject }
+      req.params = { xlsxObjectId: 'a90w49a40ao4094k4aed'}
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(res, 'json').returns({ message: "No changes"});
+      sinon.stub(XlsxObject, 'findOne').returns(fetchecdCuratedXlsxObject);
+
+      const result = await XlsxController.updateXlsxCurations(req, res, next);
+
+      expect(result).to.have.property('message');
+      expect(result.message).to.equal("No changes");
+    })
+
+    it('should return an updated xlsxObject', async () => {
+      req.body = { payload: updatedCuratedXlsxObject }
+      req.params = { xlsxObjectId: 'a90w49a40ao4094k4aed'}
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(res, 'json').returns(fetchecdCuratedXlsxObject);
+      sinon.stub(XlsxObject, 'findOne').returns(fetchecdCuratedXlsxObject);
+      sinon.stub(XlsxObject, 'findOneAndUpdate').returns(fetchecdCuratedXlsxObject);
+
+      const result = await XlsxController.updateXlsxCurations(req, res, next);
+      
+      expect(result).to.be.an('Object');
+      expect(result).to.have.property('object');
+      expect(result).to.have.property('user');
+    });
+
+    
+    it('should return a 500 server error', async function() {
+      req.body = { payload: mockCuratedXlsxObject }
+      req.params = { xlsxObjectId: 'a90w49a40ao4094k4aed'}
+      const nextSpy = sinon.spy();
+      sinon.stub(res, 'status').returnsThis();
+      sinon.stub(res, 'json').returnsThis();
+      sinon.stub(XlsxObject, 'findOne').throws();
+
+      await XlsxController.updateXlsxCurations(req, res, nextSpy);
+      sinon.assert.calledOnce(nextSpy);
+    });
+  });
+  context('createMaterialObject', () => {
+    it('should return error object', async () => {
+      
+      sinon.stub(XlsxFileManager, 'xlsxFileReader').returns(mockSheetData);
+      const error = await XlsxController.createMaterialObject(correctXlsxFile[0].path, mockJsonStructure, mockCurationListMap);
+
+      expect(error).to.be.an('Object')
+      expect(error).to.have.property('count');
+      expect(error).to.have.property('errors');
+    });
+    it('should return parsed and filtered xlsx object 1', async () => {
+      
+      sinon.stub(XlsxFileManager, 'xlsxFileReader').returns(mockSheetData2);
+      const result = await XlsxController.createMaterialObject(correctXlsxFile[0].path, mockJsonStructure, mockCurationListMap);
+
+      expect(result).to.be.an('Object')
+      expect(result).to.have.property('Your Name');
+    });
+    it('should return parsed and filtered xlsx object 2', async () => {
+      
+      sinon.stub(XlsxFileManager, 'xlsxFileReader').returns(mockSheetData3);
+      const result = await XlsxController.createMaterialObject(correctXlsxFile[0].path, mockJsonStructure2, mockCurationListMap, mockUploadedFiles);
+      expect(result).to.be.an('Object')
+      expect(result).to.have.property('DMA Datafile');
+      expect(result['DMA Datafile']).to.be.an('Array');
+    });
+
+    it('should return parsed and filtered xlsx object 3 handling default', async () => {
+      
+      sinon.stub(XlsxFileManager, 'xlsxFileReader').returns(mockSheetData4);
+      const result = await XlsxController.createMaterialObject(correctXlsxFile[0].path, mockJsonStructure4, mockCurationListMap, mockUploadedFiles);
+      console.log(result.Microstructure['Image dimension']);
+      expect(result).to.be.an('Object')
+      expect(result).to.have.property('Microstructure');
+      expect(result.Microstructure).to.have.property('Imagefile');
+      expect(result.Microstructure.Imagefile).to.be.an('Array');
+    });
+    it('should return error when file is not uploaded', async () => {
+      
+      sinon.stub(XlsxFileManager, 'xlsxFileReader').returns(mockSheetData3);
+      const error = await XlsxController.createMaterialObject(correctXlsxFile[0].path, mockJsonStructure2, mockCurationListMap, correctXlsxFile);
+
+      expect(error).to.be.an('Object')
+      expect(error).to.have.property('count');
+      expect(error).to.have.property('errors');
+    });
+  });
+});

--- a/resfulservice/spec/controllers/curationController.spec.js
+++ b/resfulservice/spec/controllers/curationController.spec.js
@@ -1,6 +1,24 @@
 const chai = require('chai');
 const sinon = require('sinon');
-const { user, correctXlsxFile, wrontXlsxFile, mockCurationList, mockCuratedXlsxObject, fetchecdCuratedXlsxObject, mockSheetData, mockSheetData2, updatedCuratedXlsxObject, mockBaseObject, mockJsonStructure, mockCurationListMap, mockSheetData3, mockSheetData4, mockJsonStructure2, mockJsonStructure4, mockUploadedFiles } = require('../mocks')
+const {
+  user,
+  correctXlsxFile,
+  wrontXlsxFile,
+  mockCurationList,
+  mockCuratedXlsxObject,
+  fetchecdCuratedXlsxObject,
+  mockSheetData,
+  mockSheetData2,
+  updatedCuratedXlsxObject,
+  mockBaseObject,
+  mockJsonStructure,
+  mockCurationListMap,
+  mockSheetData3,
+  mockSheetData4,
+  mockJsonStructure2,
+  mockJsonStructure4,
+  mockUploadedFiles 
+} = require('../mocks')
 const XlsxObject = require('../../src/models/curatedObject');
 const XlsxCurationList = require('../../src/models/xlsxCurationList');
 const XlsxFileManager = require('../../src/utils/xlsxFileManager');

--- a/resfulservice/spec/graphql/resolver/material_template.spec.js
+++ b/resfulservice/spec/graphql/resolver/material_template.spec.js
@@ -170,6 +170,16 @@ describe('Material Template Resolver Unit Tests:', function () {
       expect(error.extensions.code).to.be.equal(404);
     });
 
+    it("should delete a curation list", async () => {
+      sinon.stub(MaterialTemplate, 'findOneAndDelete').returns({
+        lean: sinon.stub().returns(mockDBColumn),
+      });
+      const result = await deleteXlsxCurationList({}, { input }, { user, req, isAuthenticated: true }); 
+
+      expect(result).to.have.property('field');
+      expect(result).to.have.property('values');
+    });
+
     it("should throw a 500, server error", async () => {
       sinon.stub(MaterialTemplate, 'findOneAndDelete').returns({
         lean: sinon.stub().throws(),
@@ -182,7 +192,7 @@ describe('Material Template Resolver Unit Tests:', function () {
   });
 
   context('getXlsxCurationList', () => {
-    const input = { ...mockColumn, pageNumber: 1, pageSize: 10 }
+    const input = { pageNumber: 1, pageSize: 10 }
     it("should throw a 401, not authenticated error", async () => {
 
       const error = await getXlsxCurationList({}, { input }, { user, req, isAuthenticated: false }); 

--- a/resfulservice/spec/mocks/curationMock.js
+++ b/resfulservice/spec/mocks/curationMock.js
@@ -1,5 +1,5 @@
 const sinon = require('sinon');
-const jsonStructure = require('../../config/spreadsheet/xlxs.json');
+const jsonStructure = require('../../config/xlsx.json');
 
 const mockCurationList = [
   {

--- a/resfulservice/spec/mocks/curationMock.js
+++ b/resfulservice/spec/mocks/curationMock.js
@@ -1,0 +1,1078 @@
+const sinon = require('sinon');
+const jsonStructure = require('../../config/spreadsheet/xlxs.json');
+
+const mockCurationList = [
+  {
+    field: 'Citation_type',
+    values: ['publications', 'lab-generated']
+  },
+  {
+    field: 'Origin',
+    values: [
+      'experiments',
+      'informatics (data science)',
+      'simulations',
+      'theory'
+    ]
+  },
+  {
+    field: 'publication_type',
+    values: ['research article', 'conference proceedings', 'communication', 'review', 'letter', 'technical comment']
+  }
+];
+
+const mockJsonStructure = {
+  'Your Name': {
+    value: '1. Data Origin|[2,1]',
+    type: 'String'
+  },
+  'Your Email': {
+    value: '1. Data Origin|[3,1]',
+    type: 'String'
+  },
+  'Sample ID': {
+    value: '1. Data Origin|[4,1]',
+    type: 'String'
+  },
+  'Control sample ID': {
+    value: '1. Data Origin|[5,1]',
+    type: 'String'
+  },
+  Origin: {
+    value: '1. Data Origin|[6,1]',
+    type: 'List',
+    validList: 'Origin'
+  },
+  'Citation Type': {
+    value: '1. Data Origin|[7,1]',
+    type: 'List',
+    validList: 'Citation_type'
+  },
+  'Publication Type': {
+    value: '1. Data Origin|[8,1]',
+    type: 'List',
+    validList: 'publication_type'
+  },
+  DOI: {
+    value: '1. Data Origin|[10,1]',
+    type: 'String'
+  },
+  Publication: {
+    value: '1. Data Origin|[15,1]',
+    type: 'String'
+  },
+  Title: {
+    value: '1. Data Origin|[16,1]',
+    type: 'String'
+  },
+  Author: {
+    type: 'multiples',
+    values: [
+      {
+        'Author #1': {
+          value: '1. Data Origin|[17,1]',
+          type: 'String'
+        }
+      },
+      {
+        'Author #2': {
+          value: '1. Data Origin|[18,1]',
+          type: 'String'
+        }
+      }
+    ]
+  },
+  'Publication Year': {
+    value: '1. Data Origin|[21,1]',
+    type: 'String'
+  },
+  Volume: {
+    value: '1. Data Origin|[22,1]',
+    type: 'String'
+  },
+  Issue: {
+    value: '1. Data Origin|[23,1]',
+    type: 'String'
+  },
+  URL: {
+    value: '1. Data Origin|[24,1]',
+    type: 'String'
+  },
+  Language: {
+    value: '1. Data Origin|[25,1]',
+    type: 'String'
+  },
+  Location: {
+    value: '1. Data Origin|[26,1]',
+    type: 'String'
+  },
+  'Date of citation': {
+    value: '1. Data Origin|[27,1]',
+    type: 'String'
+  },
+  'Laboratory Data Info': {
+    'Date of Sample Made': {
+      value: '1. Data Origin|[31,1]',
+      type: 'String'
+    },
+    'Date of Data Measurement': {
+      value: '1. Data Origin|[32,1]',
+      type: 'String'
+    },
+    'Related DOI': {
+      value: '1. Data Origin|[33,1]',
+      type: 'String'
+    }
+  }
+};
+
+const mockJsonStructure2 = {
+  'DMA Datafile': {
+    type: 'multiples',
+    values: [
+      {
+        Description: {
+          value: '5.2 Properties-Viscoelastic|[0,1]',
+          type: 'String'
+        },
+        Datafile: {
+          value: '5.2 Properties-Viscoelastic|[0,2]',
+          type: 'File'
+        },
+        Note: {
+          value: '5.2 Properties-Viscoelastic|[0,3]',
+          type: 'String'
+        }
+      },
+      {
+        Description: {
+          value: '5.2 Properties-Viscoelastic|[1,1]',
+          type: 'String'
+        },
+        Datafile: {
+          value: '5.2 Properties-Viscoelastic|[1,2]',
+          type: 'File'
+        },
+        Note: {
+          value: '5.2 Properties-Viscoelastic|[1,3]',
+          type: 'String'
+        }
+      }
+    ]
+  },
+  'Master Curve': {
+    type: 'multiples',
+    values: [
+      {
+        Description: {
+          value: '5.2 Properties-Viscoelastic|[2,1]',
+          type: 'String'
+        },
+        Datafile: {
+          value: '5.2 Properties-Viscoelastic|[2,2]',
+          type: 'File'
+        },
+        Note: {
+          value: '5.2 Properties-Viscoelastic|[2,3]',
+          type: 'String'
+        }
+      }
+    ]
+  }
+};
+
+const mockJsonStructure4 = {
+  Microstructure: {
+    Imagefile: {
+      type: 'multiples',
+      values: [
+        {
+          'Microstructure filename': {
+            'Datafile name.jpg/png/tif/gif': {
+              value: '6. Microstructure|[4,1]',
+              type: 'File',
+              validTypes: ['jpg', 'png', 'gif']
+            },
+            Note: {
+              value: '6. Microstructure|[4,2]',
+              type: 'String'
+            }
+          },
+          Description: {
+            Datafile: {
+              value: '6. Microstructure|[5,1]',
+              type: 'String'
+            },
+            Note: {
+              value: '6. Microstructure|[5,2]',
+              type: 'String'
+            }
+          },
+          'Microscopy type': {
+            Datafile: {
+              value: '6. Microstructure|[6,1]',
+              type: 'List',
+              validList: 'Imagefile::Microscopy_type::Datafile'
+            },
+            Note: {
+              value: '6. Microstructure|[6,2]',
+              type: 'String'
+            }
+          },
+          'Image type': {
+            Datafile: {
+              value: '6. Microstructure|[7,1]',
+              type: 'List',
+              validList: 'Imagefile::Image_type::Datafile'
+            },
+            Note: {
+              value: '6. Microstructure|[7,2]',
+              type: 'String'
+            }
+          }
+        }
+      ]
+    },
+    'Image dimension': {
+      Width: {
+        'Fixed Value': {
+          value: '6. Microstructure|[10,1]',
+          type: 'String'
+        },
+        Unit: {
+          value: '6. Microstructure|[10,2]',
+          type: 'String',
+          default: 'pixel'
+        },
+        Note: {
+          value: '6. Microstructure|[10,3]',
+          type: 'String'
+        }
+      },
+      Height: {
+        'Fixed Value': {
+          value: '6. Microstructure|[11,1]',
+          type: 'String'
+        },
+        Unit: {
+          value: '6. Microstructure|[11,2]',
+          type: 'String',
+          default: 'pixel'
+        },
+        Note: {
+          value: '6. Microstructure|[11,3]',
+          type: 'String'
+        }
+      },
+      Depth: {
+        'Fixed Value': {
+          value: '6. Microstructure|[12,1]',
+          type: 'String'
+        },
+        Unit: {
+          value: '6. Microstructure|[12,2]',
+          type: 'String',
+          default: 'bit'
+        },
+        Note: {
+          value: '6. Microstructure|[12,3]',
+          type: 'String'
+        }
+      },
+      Preprocessing: {
+        'Fixed Value': {
+          value: '6. Microstructure|[13,1]',
+          type: 'String'
+        },
+        Unit: {
+          value: '6. Microstructure|[13,2]',
+          type: 'String'
+        },
+        Note: {
+          value: '6. Microstructure|[13,3]',
+          type: 'String'
+        }
+      }
+    },
+    'Sample experimental info': {
+      'Sample size': {
+        'Fixed Value': {
+          value: '6. Microstructure|[16,1]',
+          type: 'String'
+        },
+        Unit: {
+          value: '6. Microstructure|[16,2]',
+          type: 'List',
+          validList: 'Sample_experimental_info::Sample_size::Unit'
+        },
+        Note: {
+          value: '6. Microstructure|[16,3]',
+          type: 'String'
+        }
+      },
+      'Sample thickness': {
+        'Fixed Value': {
+          value: '6. Microstructure|[17,1]',
+          type: 'String'
+        },
+        Unit: {
+          value: '6. Microstructure|[17,2]',
+          type: 'List',
+          validList: 'Sample_experimental_info::Sample_thickness::Unit'
+        },
+        Note: {
+          value: '6. Microstructure|[17,3]',
+          type: 'String'
+        }
+      }
+    }
+  }
+};
+const mockCurationListMap = {
+  citation_type: ['publications', 'lab-generated'],
+  Origin: [
+    'experiments',
+    'informatics (data science)',
+    'simulations',
+    'theory'
+  ],
+  publication_type: [
+    'research article',
+    'conference proceedings',
+    'communication',
+    'review',
+    'letter',
+    'technical comment'
+  ]
+};
+
+const mockSheetData = [
+  ['Sample Info', null, 'Note', null],
+  [
+    'Instructions: Each excel file is for a single sample. For multiple similar samples, duplicate the file and change only the necessary data. One file = one sample.',
+    null,
+    null,
+    null
+  ],
+  ['Your Name', 'Gbolahan', 'Data contributor\'s name', null],
+  ['Your Email', 'gbolahan.adeleke@toluconsulting.com', null, null],
+  [
+    'Sample ID',
+    null,
+    'name your sample in the format of SAMPLE NO',
+    'Example: S1'
+  ],
+  ['Control sample ID', null, null, null],
+  ['Origin', 'theorys', null, null],
+  ['Citation Type', 'lab-generated', null, null],
+  ['Publication Type', 'research article', null, null],
+  [null, null, null, null],
+  ['DOI', null, null, null],
+  [null, null, null, null],
+  [
+    'If you have a DOI, then STOP HERE on this tab! Rest will be autofilled from DOI.',
+    null,
+    null,
+    null
+  ],
+  [
+    'Without DOI yet? Please fill out the following info.',
+    null,
+    null,
+    null
+  ],
+  [null, null, null, null],
+  ['Publication', null, null, null],
+  ['Title', 'Backend developer', null, null],
+  ['Author #1', null, 'copy and paste more rows if needed', null],
+  ['Author #2', null, null, null],
+  ['Keyword #1', null, null, null],
+  ['Keyword #2', null, null, null],
+  ['Publication Year', null, null, null],
+  ['Volume', null, null, null],
+  ['Issue', null, null, null],
+  ['URL', null, null, null],
+  ['Language', null, null, null],
+  [
+    'Location',
+    null,
+    'please put first author\'s major affiliation here',
+    null
+  ],
+  ['Date of citation', null, 'mm/dd/yyyy', null],
+  [null, null, null, null],
+  [
+    'If lab generated, please fill in the lab data info below:',
+    null,
+    null,
+    null
+  ],
+  ['Laboratory Data Info', null, null, null],
+  [
+    'Date of Sample Made',
+    '2023-03-23T00:00:00.000Z',
+    'mm/dd/yyyy',
+    null
+  ],
+  [
+    'Date of Data Measurement',
+    '2023-03-23T00:00:00.000Z',
+    'mm/dd/yyyy',
+    null
+  ],
+  [
+    'Related DOI',
+    'test DOI',
+    'for unreported lab data of a published work',
+    null
+  ]
+];
+
+const mockSheetData2 = [
+  ['Sample Info', null, 'Note', null],
+  [
+    'Instructions: Each excel file is for a single sample. For multiple similar samples, duplicate the file and change only the necessary data. One file = one sample.',
+    null,
+    null,
+    null
+  ],
+  ['Your Name', 'Gbolahan', 'Data contributor\'s name', null],
+  ['Your Email', 'gbolahan.adeleke@toluconsulting.com', null, null],
+  [
+    'Sample ID',
+    null,
+    'name your sample in the format of SAMPLE NO',
+    'Example: S1'
+  ],
+  ['Control sample ID', null, null, null],
+  ['Origin', null, null, null],
+  ['Citation Type', 'lab-generated', null, null],
+  ['Publication Type', 'research article', null, null],
+  [null, null, null, null],
+  ['DOI', null, null, null],
+  [null, null, null, null],
+  [
+    'If you have a DOI, then STOP HERE on this tab! Rest will be autofilled from DOI.',
+    null,
+    null,
+    null
+  ],
+  [
+    'Without DOI yet? Please fill out the following info.',
+    null,
+    null,
+    null
+  ],
+  [null, null, null, null],
+  ['Publication', null, null, null],
+  ['Title', 'Backend developer', null, null],
+  ['Author #1', 'gbolahan adeleke', 'copy and paste more rows if needed', null],
+  ['Author #2', null, null, null],
+  ['Keyword #1', null, null, null],
+  ['Keyword #2', null, null, null],
+  ['Publication Year', null, null, null],
+  ['Volume', null, null, null],
+  ['Issue', null, null, null],
+  ['URL', null, null, null],
+  ['Language', null, null, null],
+  [
+    'Location',
+    null,
+    'please put first author\'s major affiliation here',
+    null
+  ],
+  ['Date of citation', null, 'mm/dd/yyyy', null],
+  [null, null, null, null],
+  [
+    'If lab generated, please fill in the lab data info below:',
+    null,
+    null,
+    null
+  ],
+  ['Laboratory Data Info', null, null, null],
+  [
+    'Date of Sample Made',
+    '2023-03-23T00:00:00.000Z',
+    'mm/dd/yyyy',
+    null
+  ],
+  [
+    'Date of Data Measurement',
+    '2023-03-23T00:00:00.000Z',
+    'mm/dd/yyyy',
+    null
+  ],
+  [
+    'Related DOI',
+    'test DOI',
+    'for unreported lab data of a published work',
+    null
+  ]
+];
+
+const mockSheetData3 = [
+  [
+    'DMA Datafile #',
+    null,
+    'Matester_template.xlsx',
+    '.xlsx, .csv, .tsv',
+    null,
+    null,
+    null,
+    null
+  ],
+  [
+    'DMA Datafile #',
+    null,
+    'Bello.xlsx',
+    '.xlsx, .csv, .tsv',
+    null,
+    null,
+    null,
+    null
+  ],
+  [
+    'Master Curve #',
+    null,
+    'master-template.xlsx',
+    '.xlsx, .csv, .tsv',
+    null,
+    null,
+    null,
+    null
+  ]
+];
+
+const mockSheetData4 = [
+  ['Microstructure', null, null, null],
+  [
+    'Instructions: Include as many high quality microstructure images as desired. \n' +
+        '1. Put the filename in the corresponding box (line 5); \n' +
+        '2. include other details of images as available. \n' +
+        '3. For each added image, copy and paste all sections in the box as shown for Imagefile #.\n' +
+        '4. Enter filename and details for each image.',
+    null,
+    null,
+    null
+  ],
+  [null, null, null, null],
+  ['Imagefile #', 'Datafile name.jpg/png/tif/gif', 'Note', null],
+  ['Microstructure filename', '001.tif', null, null],
+  ['Description', '40000x magnification', null, null],
+  ['Microscopy type', 'TEM', null, null],
+  ['Image type', 'grayscale', null, null],
+  [null, null, null, null],
+  ['Image dimension', 'Fixed Value', 'Unit', 'Note'],
+  ['Width', null, null, null],
+  ['Height', null, 'pixel', null],
+  ['Depth', null, 'bit', null],
+  ['Preprocessing', null, null, null],
+  [null, null, null, null],
+  ['Sample experimental info', 'Fixed Value', 'Unit', 'Note'],
+  ['Sample size', null, null, null],
+  ['Sample thickness', 50, 'nm', null]
+];
+
+const mockCuratedXlsxObject = {
+  'Your Name': 'Tolulomo Fateye',
+  'Your Email': 'tolulomo@toluconsulting.com',
+  'Sample ID': 'S10',
+  'Control sample ID': 'S28',
+  Origin: 'experiments',
+  'Citation Type': 'lab-generated',
+  Author: [
+    {
+      'Author #1': 'Aditya Shanker Prasad'
+    }
+  ],
+  URL: 'https://search.proquest.com/openview/eb63d4d6b84b1252971b3e3eec53b97c/1?pq-origsite=gscholar&cbl=51922&diss=y',
+  Location: 'Rensselaer Polytechnic Institute',
+  Matrix: [
+    {
+      'Chemical name': {
+        Description: 'Polystyrene'
+      },
+      Abbreviation: {
+        Description: 'PS'
+      },
+      'Polymer plastic type': {
+        Description: 'thermoplastic'
+      },
+      'Polymer class': {
+        Description: 'Polystyrene'
+      },
+      'Polymer type': {
+        Description: 'homopolymer'
+      },
+      'Polymer manufacturer or source name': {
+        Description: 'Sigma Aldrich'
+      },
+      'Polymer molecular weight': {
+        Description: 'weight average (Mw)',
+        Value: 50000,
+        Unit: 'g/mol'
+      }
+    }
+  ],
+  Filler: [
+    {
+      'Filler chemical name/Filler name': {
+        Description: 'Silica'
+      },
+      'Manufacturer or source name': {
+        Description: 'Nissan'
+      },
+      'Trade name': {
+        Description: 'MEKST'
+      },
+      Density: {
+        Value: 2.65,
+        Unit: 'g/cm^3'
+      },
+      'Crystal phase': {
+        Description: 'amorphous'
+      },
+      'Particle diameter': {
+        Value: 14,
+        Unit: 'nm'
+      }
+    }
+  ],
+  'Filler Composition': {
+    Fraction: 'mass'
+  },
+  'Particle Surface Treatment (PST)': [
+    {
+      'PST chemical name': {
+        Description: 'aminopropyledimethylethoxysilane'
+      },
+      'PST abbreviation': {
+        Description: 'APDMES'
+      },
+      'PST manufacturer or source name': {
+        Description: 'Gelest Inc.'
+      },
+      'PST density': {
+        Value: 0.857,
+        Unit: 'g/cm^3'
+      },
+      'PST molecular weight': {
+        Value: 161.32,
+        Unit: 'g/mol'
+      }
+    }
+  ],
+  'Surface Chemical Processing': {
+    Mixing: [
+      {
+        'Mixing - description': {
+          'Description/Fixed Value': '16 ml of MEK-ST (Nissan) was taken in a flask along with 50 ml of THF and 0.5 ml of the silane coupling agent. The solution was stirred and refluxed at 70°C under an inert N2 atmosphere for 24 hours.'
+        },
+        'Mixing - method': {
+          'Description/Fixed Value': 'stirring'
+        },
+        'Mixing - time': {
+          'Description/Fixed Value': 24,
+          Unit: 'hours'
+        },
+        'Mixing - temperature': {
+          'Description/Fixed Value': 70,
+          Unit: 'Celsius'
+        },
+        'Mixing - chemical used': {
+          0: {
+            Name: 'tetrahydrofuran',
+            Value: 50,
+            Unit: 'mL'
+          },
+          1: {
+            Name: 'silane',
+            Value: 0.5,
+            Unit: 'mL'
+          },
+          2: {
+            Name: 'silica',
+            Value: 16,
+            Unit: 'mL'
+          }
+        }
+      }
+    ],
+    Cooling: [
+      {
+        'Cooling - description': {
+          'Description/Fixed Value': 'The mixture was cooled down to room temperature'
+        },
+        'Cooling - temperature': {
+          'Description/Fixed Value': 28,
+          Unit: 'Celsius'
+        },
+        'Cooling - ambient condition': {
+          Mode: 'atmosphere'
+        }
+      }
+    ],
+    'Drying/Evaporation': [
+      {
+        'Drying/Evaporation - description': {
+          'Description/Fixed Value': 'THF was reduced to 20 ml in a rotor evaporator in order to reduce the amount of needed hexane.'
+        }
+      }
+    ],
+    Solvent: [
+      {
+        'Solvent - solvent amount': {
+          Name: 'hexane',
+          Value: 20,
+          Unit: 'mL'
+        }
+      }
+    ],
+    Centrifugation: [
+      {
+        Name: 'Used'
+      }
+    ],
+    Other: [
+      {
+        'Other - description': {
+          Description: 'The mixture was precipitated in 200 ml of hexane. The particles were then centrifuged at 10,000 rpm for 10 min at 10 deg C.'
+        }
+      }
+    ]
+  },
+  'Experimental Procedure': 'Sample mixing at 50 RPM, specific energy input 500 kJ/kg',
+  'Processing method': [
+    {
+      'Processing method #': 'MeltMixing'
+    }
+  ],
+  Mixing: [
+    {
+      'Mixing - description': {
+        'Description/Fixed Value': 'The nanoparticles were precipitated out in DI water and were mixed with polymer.'
+      },
+      'Mixing - method': {
+        'Description/Fixed Value': 'dissolving'
+      }
+    }
+  ],
+  'Drying/Evaporation': [
+    {
+      'Drying/Evaporation - description': {
+        'Description/Fixed Value': 'This solution was dried in a vacuum oven at 90°C for 12 hours to ensure the removal of any remnants'
+      },
+      'Drying/Evaporation - temperature': {
+        'Description/Fixed Value': 90,
+        Unit: 'Celsius'
+      },
+      'Drying/Evaporation - time': {
+        'Description/Fixed Value': 12,
+        Unit: 'hours'
+      },
+      'Drying/Evaporation - ambient condition': {
+        Mode: 'vacuum'
+      }
+    }
+  ],
+  Other: [
+    {
+      'Other - description': {
+        Description: 'The mixtures were then milled in a jet milling machine in order to reduce the starting agglomerate size.'
+      }
+    }
+  ],
+  Extrusion: [
+    {
+      'Extrusion - Twin screw extrusion': {
+        Extruder: {
+          'Description/Fixed Value': 'Thermo Haake Minilab'
+        },
+        'Residence time': {
+          'Description/Fixed Value': 531,
+          Unit: 'seconds'
+        },
+        'Extrusion temperature': {
+          'Description/Fixed Value': 150,
+          Unit: 'Celsius'
+        },
+        'Rotation mode': {
+          'Description/Fixed Value': 'CounterRotation'
+        },
+        'Screw diameter': {
+          'Description/Fixed Value': 12.7,
+          Unit: 'mm'
+        },
+        'Screw channel diameter': {
+          'Description/Fixed Value': 0.56,
+          Unit: 'mm'
+        },
+        'Heating zone': [
+          {
+            'Rotation speed': {
+              'Description/Fixed Value': 50
+            }
+          }
+        ],
+        Output: {
+          'Output - Melt temperature': {
+            'Description/Fixed Value': 150,
+            Unit: 'Celsius'
+          },
+          'Output - Pressure at die': {
+            'Description/Fixed Value': 8,
+            Unit: 'MPa'
+          },
+          'Output - Torque': {
+            'Description/Fixed Value': 0.9,
+            Unit: 'Nm'
+          },
+          'Output - Residence time': {
+            'Description/Fixed Value': 531,
+            Unit: 'seconds'
+          }
+        }
+      }
+    }
+  ],
+  Microscopy: {
+    'Transmission electron microscopy': {
+      'Equipment used': {
+        Description: 'JEOL-2010'
+      },
+      'Equipment description': {
+        Description: 'To observe the dispersion of the nanoparticles in the polymer matrix, the materials were embedded in an epoxy matrix and slices of *50 nm were sectioned at room temperature in an ultramicrotome using a diamond knife. The sections were collected on a copper grid and imaged in a JEOL-2010 transmission electron microscope (TEM).'
+      },
+      Magnification: {
+        'Fixed Value': 60000
+      },
+      'Accelerating voltage': {
+        'Fixed Value': 200,
+        Unit: 'kV'
+      }
+    }
+  },
+  Spectroscopy: {
+    'Dielectric and impedance spectroscopy analysis': {
+      'Equipment used': {
+        Description: 'Novocontrol Alpha Impedance'
+      }
+    }
+  },
+  'AC dielectric dispersion #': {
+    Dependence: {
+      'Description/Condition': 'Frequency dependence'
+    },
+    'Test Conditions - Temperature': {
+      'Description/Condition': 'room temperature',
+      'Fixed Value': 25,
+      Unit: 'Celsius',
+      Note: 'only fill in when it\'s frequency dependence'
+    },
+    'Test Conditions - Frequency': {
+      Note: 'only fill in when it\'s temperature dependence'
+    },
+    'Real permittivity': {
+      Datafile: 'real_permittivity.csv'
+    },
+    'Loss permittivity': {
+      Datafile: 'loss_permittivity.csv'
+    },
+    'Loss tangent': {
+      Datafile: 'tan_delta.csv'
+    },
+    'Dielectric breakdown strength': {
+      Condition: 'AC',
+      'Fixed Value': 117.3842,
+      Unit: 'kV/mm'
+    },
+    'Weibull plot': {
+      Datafile: 'weibull.csv'
+    },
+    'Weibull parameter - scale': [
+      {
+        'Fixed Value': 8.602
+      }
+    ],
+    'Weibull parameter - shape': [
+      {
+        'Fixed Value': 8.602
+      }
+    ]
+  },
+  Microstructure: {
+    Imagefile: [
+      {
+        'Microstructure filename': {
+          'Datafile name.jpg/png/tif/gif': 'architectural_canid_atlante-2023-05-04T13:32:19.832Z-001.tif'
+        },
+        Description: {
+          Datafile: '40000x magnification'
+        },
+        'Microscopy type': {
+          Datafile: 'TEM'
+        },
+        'Image type': {
+          Datafile: 'grayscale'
+        }
+      }
+    ],
+    'Image dimension': {
+      Width: {
+        Unit: 'pixel'
+      },
+      Height: {
+        Unit: 'pixel'
+      },
+      Depth: {
+        Unit: 'bit'
+      }
+    },
+    'Sample experimental info': {
+      'Sample thickness': {
+        'Fixed Value': 50,
+        Unit: 'nm'
+      }
+    }
+  }
+};
+
+const updatedCuratedXlsxObject = {
+  ...mockCuratedXlsxObject,
+  'Your Name': 'Uthdev'
+};
+
+const createBaseObject = (obj, savedObj) => {
+  const newObj = {};
+  for (const prop in obj) {
+    const propVal = obj[prop];
+    if (Array.isArray(propVal?.values)) {
+      const objArr = propVal.values.map((obj, i) => createBaseObject(obj, savedObj?.[prop]?.[i]));
+      newObj[prop] = objArr;
+    } else if (propVal?.value) {
+      if (savedObj?.[prop]) {
+        newObj[prop] = savedObj[prop];
+      } else {
+        newObj[prop] = null;
+      }
+    } else {
+      const nestedObj = createBaseObject(propVal, savedObj?.[prop]);
+
+      if (Object.keys(nestedObj).length > 0) {
+        newObj[prop] = nestedObj;
+      }
+    }
+  }
+  return newObj;
+};
+
+const mockBaseObject = createBaseObject(jsonStructure, mockCuratedXlsxObject);
+
+const fetchecdCuratedXlsxObject = {
+  object: mockCuratedXlsxObject,
+  user: {
+    _id: '62f119fb28eedaab012d1262',
+    givenName: 'Gbolahan',
+    surName: 'Adeleke'
+  },
+  _id: '642561166202628c4aff8d59',
+  createdAt: '2023-03-30T10:14:46.072Z',
+  updatedAt: '2023-03-30T10:14:46.072Z',
+  __v: 0,
+  populate: sinon.stub().resolvesThis()
+};
+
+const wrontXlsxFile = [
+  {
+    fieldname: 'uploadfile',
+    originalname: 'Matester template.xlsx',
+    encoding: '7bit',
+    mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    destination: 'mm_files',
+    filename: 'coloured_monkey_celestia-2023-03-30T09:59:24.432Z-Matester template.xlsx',
+    path: 'mm_files/coloured_monkey_celestia-2023-03-30T09:59:24.432Z-Matester template.xlsx',
+    size: 101176
+  }
+];
+
+const correctXlsxFile = [
+  {
+    fieldname: 'uploadfile',
+    originalname: 'master_template.xlsx',
+    encoding: '7bit',
+    mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    destination: 'mm_files',
+    filename: 'coloured_monkey_celestia-2023-03-30T09:51:10.334Z-master_template.xlsx',
+    path: 'mm_files/coloured_monkey_celestia-2023-03-30T09:51:10.334Z-master_template.xlsx',
+    size: 101191
+  }
+];
+
+const mockUploadedFiles = [
+  {
+    fieldname: 'uploadfile',
+    originalname: 'master-template.xlsx',
+    encoding: '7bit',
+    mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    destination: 'mm_files',
+    filename: 'educational_hornet_maisie-2023-04-18T16:01:27.609Z-master-template.xlsx',
+    path: 'mm_files/educational_hornet_maisie-2023-04-18T16:01:27.609Z-master-template.xlsx',
+    size: 104928
+  },
+  {
+    fieldname: 'uploadfile',
+    originalname: 'Bello.xlsx',
+    encoding: '7bit',
+    mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    destination: 'mm_files',
+    filename: 'educational_hornet_maisie-2023-04-18T16:01:27.616Z-Bello.xlsx',
+    path: 'mm_files/educational_hornet_maisie-2023-04-18T16:01:27.616Z-Bello.xlsx',
+    size: 101196
+  },
+  {
+    fieldname: 'uploadfile',
+    originalname: 'Matester_template.xlsx',
+    encoding: '7bit',
+    mimetype: 'application/vnd.openxmlformats-officedocument.spreadsheetml.sheet',
+    destination: 'mm_files',
+    filename: 'educational_hornet_maisie-2023-04-18T16:01:27.625Z-Matester_template.xlsx',
+    path: 'mm_files/educational_hornet_maisie-2023-04-18T16:01:27.625Z-Matester_template.xlsx',
+    size: 101196
+  },
+  {
+    fieldname: 'uploadfile',
+    originalname: '001.tif',
+    encoding: '7bit',
+    mimetype: 'image/tiff',
+    destination: 'mm_files',
+    filename: 'exciting_spoonbill_ermentrude-2023-05-05T11:25:53.451Z-001.tif',
+    path: 'mm_files/exciting_spoonbill_ermentrude-2023-05-05T11:25:53.451Z-001.tif',
+    size: 101196
+  }
+];
+
+const user = {
+  _id: 'ai094oja09aw40-o',
+  displayName: 'test'
+};
+
+module.exports = {
+  user,
+  correctXlsxFile,
+  wrontXlsxFile,
+  mockCurationList,
+  mockCuratedXlsxObject,
+  fetchecdCuratedXlsxObject,
+  mockSheetData,
+  updatedCuratedXlsxObject,
+  mockBaseObject,
+  jsonStructure,
+  mockCurationListMap,
+  mockJsonStructure,
+  mockSheetData2,
+  mockJsonStructure2,
+  mockSheetData3,
+  mockSheetData4,
+  mockJsonStructure4,
+  mockUploadedFiles
+};

--- a/resfulservice/spec/mocks/index.js
+++ b/resfulservice/spec/mocks/index.js
@@ -1,0 +1,5 @@
+const curation = require('./curationMock');
+
+module.exports = {
+  curation
+};

--- a/resfulservice/spec/mocks/index.js
+++ b/resfulservice/spec/mocks/index.js
@@ -1,5 +1,5 @@
 const curation = require('./curationMock');
 
 module.exports = {
-  curation
+  ...curation
 };

--- a/resfulservice/src/controllers/authController.js
+++ b/resfulservice/src/controllers/authController.js
@@ -6,7 +6,11 @@ const { supportedBrowser, userRoles } = require('../../config/constant');
 
 // Generate and send token info to FE
 const _redirect = ({ _id, email, displayName, givenName, surName, roles }, req, res) => {
-  const isAdmin = roles === userRoles.isAdmin;
+  let isAdmin = roles === userRoles.isAdmin;
+
+  if (req.env?.MM_RUNTIME_ENV === 'dev') {
+    isAdmin = true;
+  }
 
   successWriter(req, 'success', 'Found/Created user successfully');
   const token = setInternal(req, { _id, email, displayName, givenName, surName, isAdmin });
@@ -29,10 +33,6 @@ const _validateUser = async (req) => {
 
   const email = req.headers[env.MM_AUTH_EMAIL_HEADER] ?? env.MM_USER_EMAIL;
   const userExist = await User.findOne({ email });
-
-  if (env?.MM_RUNTIME_ENV === 'dev') {
-    userExist.roles = userRoles.isAdmin;
-  }
 
   if (userExist) return userExist;
 

--- a/resfulservice/src/controllers/curationController.js
+++ b/resfulservice/src/controllers/curationController.js
@@ -1,0 +1,218 @@
+const util = require('util');
+const XlsxFileManager = require('../utils/xlsxFileManager');
+const jsonStructure = require('../../config/xlsx.json');
+const XlsxObject = require('../models/curatedObject');
+const { errorWriter } = require('../utils/logWriter');
+const XlsxCurationList = require('../models/xlsxCurationList');
+
+exports.curateXlsxSpreadsheet = async (req, res, next) => {
+  req.logger.info('createXlsxObject Function Entry:');
+  const { user } = req;
+  if (!req.files?.uploadfile) {
+    return next(errorWriter(req, 'Material template files not uploaded', 'createXlsxObject', 400));
+  }
+
+  const regex = /master_template.xlsx$/gi;
+  const xlsxFile = req.files.uploadfile.find((file) => regex.test(file?.path));
+
+  if (!xlsxFile) {
+    return next(errorWriter(req, 'Master template xlsx file not uploaded', 'createXlsxObject', 400));
+  }
+
+  try {
+    const validList = await XlsxCurationList.find({}, null, { lean: true });
+    const validListMap = generateCurationListMap(validList);
+
+    const result = await this.createMaterialObject(xlsxFile.path, jsonStructure, validListMap, req.files.uploadfile);
+
+    if (result?.count) return res.status(400).json({ errors: result.errors });
+
+    const xlsxObj = new XlsxObject({ object: result, user: user?._id });
+    await (await xlsxObj.save()).populate({ path: 'user', select: 'givenName surName' });
+
+    return res.status(201).json(xlsxObj);
+  } catch (err) {
+    next(errorWriter(req, err, 'createXlsxObject', 500));
+  }
+};
+
+exports.getXlsxCurations = async (req, res, next) => {
+  req.logger.info('getXlsxObject Function Entry:');
+  const { user } = req;
+  const { xlsxObjectId } = req.query;
+  const filter = {};
+
+  if (user?.roles !== 'admin') filter.user = user._id;
+
+  try {
+    if (xlsxObjectId) {
+      const xlsxObject = await XlsxObject.findOne({ _id: xlsxObjectId, ...filter }, null, { lean: true, populate: { path: 'user', select: 'givenName surName' } });
+
+      if (!xlsxObject) return next(errorWriter(req, 'Xlsx Object not found', 'getXlsxObject', 404));
+
+      const baseUserObject = createBaseObject(jsonStructure, xlsxObject.object);
+      return res.status(200).json({ ...xlsxObject, object: baseUserObject });
+    } else {
+      const xlsxObjects = await XlsxObject.find(filter, { user: 1, createdAt: 1, updatedAt: 1, _v: 1 }, { lean: true, populate: { path: 'user', select: 'givenName surName' } });
+      return res.status(200).json(xlsxObjects);
+    }
+  } catch (err) {
+    next(errorWriter(req, err, 'getXlsxObject', 500));
+  }
+};
+
+exports.updateXlsxCurations = async (req, res, next) => {
+  req.logger.info('updateXlsxObject Function Entry:');
+  const { user, body: { payload } } = req;
+  try {
+    const { xlsxObjectId } = req.params;
+    const storedObject = await XlsxObject.findOne({ _id: xlsxObjectId }, null, { lean: true, populate: { path: 'user', select: 'givenName surName' } });
+
+    if (!storedObject) return next(errorWriter(req, 'Xlsx Object not found', 'getXlsxObject', 404));
+
+    const baseUserObject = createBaseObject(jsonStructure, storedObject.object);
+    const isObjChanged = !util.isDeepStrictEqual(baseUserObject, payload);
+
+    if (isObjChanged) {
+      const filteredObject = filterNestedObject(payload);
+      const updatedObject = await XlsxObject.findOneAndUpdate({ user: user._id }, { $set: { object: filteredObject } }, { new: true, lean: true, populate: { path: 'user', select: 'givenName surName' } });
+      return res.status(200).json(updatedObject);
+    }
+
+    return res.status(304).json({ message: 'No changes' });
+  } catch (err) {
+    next(errorWriter(req, err, 'updateXlsxObject', 500));
+  }
+};
+
+exports.createMaterialObject = async (path, obj, validListMap, uploadedFiles, errors = {}) => {
+  const sheetsData = {};
+  const filteredObject = {};
+
+  for (const property in obj) {
+    const propertyValue = obj[property];
+
+    if (Array.isArray(propertyValue?.values)) {
+      const multiples = propertyValue.values;
+      const objArr = [];
+      for (const prop of multiples) {
+        const newObj = await this.createMaterialObject(path, prop, validListMap, uploadedFiles, errors);
+        if (Object.keys(newObj).length > 0) {
+          objArr.push(newObj);
+        }
+      }
+      if (objArr.length > 0) {
+        filteredObject[property] = objArr;
+      }
+    } else if (Object.getOwnPropertyDescriptor(propertyValue, 'value')) {
+      const [sheetName, row, col] = propertyValue.value.replace(/[[\]]/g, '').split(/\||,/);
+
+      if (!Object.getOwnPropertyDescriptor(sheetsData, sheetName)) {
+        sheetsData[sheetName] = await XlsxFileManager.xlsxFileReader(path, sheetName);
+      }
+
+      // added plus(+) to parse as integer
+      const cellValue = sheetsData[sheetName]?.[+row]?.[+col];
+
+      if (cellValue) {
+        if (Object.getOwnPropertyDescriptor(propertyValue, 'validList')) {
+          const validListKey = propertyValue.validList;
+          const validList = validListMap[validListKey];
+
+          if (!validList && cellValue !== null) {
+            filteredObject[property] = cellValue;
+          } else if (validList?.includes(cellValue)) {
+            filteredObject[property] = cellValue;
+          } else if (cellValue !== null) {
+            errors[validListKey] = 'Invalid value';
+          }
+        } else if (propertyValue.type === 'File') {
+          const regex = new RegExp(`${cellValue}$`, 'gi');
+          const file = uploadedFiles?.find((file) => regex.test(file?.path));
+          if (file) {
+            filteredObject[property] = file.filename;
+          } else {
+            errors[cellValue] = 'file not uploaded';
+          }
+        } else {
+          if (cellValue !== null) {
+            filteredObject[property] = cellValue;
+          }
+        }
+      } else if (cellValue === null && propertyValue?.default) {
+        filteredObject[property] = propertyValue.default;
+      }
+    } else {
+      const nestedObj = await this.createMaterialObject(path, propertyValue, validListMap, uploadedFiles, errors);
+
+      if (Object.keys(nestedObj).length > 0) {
+        filteredObject[property] = nestedObj;
+      }
+    }
+  }
+
+  if (Object.keys(errors)?.length) return { errors, count: Object.keys(errors)?.length };
+
+  return filteredObject;
+};
+
+const generateCurationListMap = (curationList) => {
+  const obj = {};
+
+  for (const list of curationList) {
+    obj[list.field] = list.values;
+  }
+  return obj;
+};
+
+function filterNestedObject (obj) {
+  const newObj = {};
+  for (const prop in obj) {
+    const value = obj[prop];
+    if (Array.isArray(value)) {
+      const objArr = [];
+      for (const prop of value) {
+        const newObj = filterNestedObject(prop);
+        if (Object.keys(newObj).length > 0) {
+          objArr.push(newObj);
+        }
+      }
+      if (objArr.length > 0) {
+        newObj[prop] = objArr;
+      }
+    } else if (typeof value === 'object') {
+      const nestedObj = filterNestedObject(value);
+
+      if (Object.keys(nestedObj).length > 0) {
+        newObj[prop] = nestedObj;
+      }
+    } else if (value !== null) {
+      newObj[prop] = value;
+    }
+  }
+  return newObj;
+}
+
+const createBaseObject = (obj, savedObj) => {
+  const newObj = {};
+  for (const prop in obj) {
+    const propVal = obj[prop];
+    if (Array.isArray(propVal?.values)) {
+      const objArr = propVal.values.map((obj, i) => createBaseObject(obj, savedObj?.[prop]?.[i]));
+      newObj[prop] = objArr;
+    } else if (propVal?.value) {
+      if (savedObj?.[prop]) {
+        newObj[prop] = savedObj[prop];
+      } else {
+        newObj[prop] = null;
+      }
+    } else {
+      const nestedObj = createBaseObject(propVal, savedObj?.[prop]);
+
+      if (Object.keys(nestedObj).length > 0) {
+        newObj[prop] = nestedObj;
+      }
+    }
+  }
+  return newObj;
+};

--- a/resfulservice/src/graphql/resolver/material_template/mutation.js
+++ b/resfulservice/src/graphql/resolver/material_template/mutation.js
@@ -1,4 +1,4 @@
-const MaterialTemplate = require('../../../models/xlsxCurationList');
+const XlsxCurationList = require('../../../models/xlsxCurationList');
 const errorFormater = require('../../../utils/errorFormater');
 
 const materialMutation = {
@@ -18,12 +18,12 @@ const materialMutation = {
   updateXlsxCurationList: async (_, { input }, { user, req, isAuthenticated }) => {
     req.logger?.info('[updateMaterialColumn] Function Entry:');
     if (!isAuthenticated) {
-      req.logger?.error('[updateMaterialColumn]: User not authenticated to view contact listing');
+      req.logger?.error('[updateMaterialColumn]: User not authenticated to update CurationList');
       return errorFormater('not authenticated', 401);
     }
     const { field } = input;
     try {
-      const column = await MaterialTemplate.findOneAndUpdate({ field }, { $set: { ...input, user: user._id } }, { new: true, lean: true, populate: { path: 'user', select: 'displayName' } });
+      const column = await XlsxCurationList.findOneAndUpdate({ field }, { $set: { ...input, user: user._id } }, { new: true, lean: true, populate: { path: 'user', select: 'displayName' } });
       if (!column) return errorFormater('column not found', 404);
       req.logger?.info(`[updateMaterialColumn]: column successfully updated: ${column.field}`);
       return { ...column, user: column.user.displayName };
@@ -41,7 +41,7 @@ const materialMutation = {
     }
     const { field } = input;
     try {
-      const column = await MaterialTemplate.findOneAndDelete({ field }).lean();
+      const column = await XlsxCurationList.findOneAndDelete({ field }).lean();
       if (!column) return errorFormater('column not found', 404);
       req.logger?.info(`[deleteMaterialColumn]: column successfully deleted: ${column.field}`);
       return column;
@@ -54,7 +54,7 @@ const materialMutation = {
 
 async function insertMany (columns) {
   try {
-    await MaterialTemplate.insertMany(columns, { ordered: false, rawResult: true, lean: true });
+    await XlsxCurationList.insertMany(columns, { ordered: false, rawResult: true, lean: true });
   } catch (e) {
     return e.writeErrors.map(({ err: { errmsg } }) => errmsg.split('key:')[1]);
   }

--- a/resfulservice/src/middlewares/validations.js
+++ b/resfulservice/src/middlewares/validations.js
@@ -1,4 +1,4 @@
-const { param, validationResult } = require('express-validator');
+const { param, validationResult, body } = require('express-validator');
 
 exports.validateImageType = [
   param('imageType').not().isEmpty().withMessage('image type required').bail().isIn(['tiff', 'tif']).withMessage('only supports tiff & tif migration'),
@@ -10,11 +10,17 @@ exports.validateAcceptableUploadType = [
   validationErrorHandler
 ];
 
+exports.validateXlsxObjectUpdate = [
+  param('xlsxObjectId').not().isEmpty().withMessage('xlsx object ID required').bail().isMongoId().withMessage('invalid xlsx object id'),
+  body('payload').isObject().withMessage('please provide xlsx object for update'),
+  validationErrorHandler
+];
+
 exports.validateImageId = [param('fileId').not().isEmpty().withMessage('image ID required').bail().isMongoId().withMessage('invalid file id'), validationErrorHandler];
 
 function validationErrorHandler (req, res, next) {
   const errors = validationResult(req);
-  if (!errors.isEmpty()) return res.status(403).json({ success: false, message: 'validation error', data: errors.array() });
+  if (!errors.isEmpty()) return res.status(400).json({ success: false, message: 'validation error', data: errors.array() });
   return next();
 };
 

--- a/resfulservice/src/models/curatedObject.js
+++ b/resfulservice/src/models/curatedObject.js
@@ -1,0 +1,20 @@
+const mongoose = require('mongoose');
+const Schema = mongoose.Schema;
+
+const curatedObjectSchema = new Schema({
+  object: {
+    type: Schema.Types.Mixed,
+    required: true
+  },
+  // sampleType: {
+  //   type: String,
+  //   required: true
+  // },
+  user: {
+    type: Schema.Types.ObjectId,
+    ref: 'User',
+    required: true
+  }
+}, { timestamps: true });
+
+module.exports = mongoose.model('curatedObject', curatedObjectSchema);

--- a/resfulservice/src/routes/curation.js
+++ b/resfulservice/src/routes/curation.js
@@ -1,0 +1,22 @@
+const express = require('express');
+const router = express.Router();
+const xlsxController = require('../controllers/curationController');
+const isAuth = require('../middlewares/isAuth');
+const { validateXlsxObjectUpdate } = require('../middlewares/validations');
+
+router.route('/new')
+  .post(isAuth, xlsxController.curateXlsxSpreadsheet);
+
+router.route('/get')
+  .get(isAuth, xlsxController.getXlsxCurations);
+
+router.route('/update/:xlsxObjectId')
+  .put(validateXlsxObjectUpdate, isAuth, xlsxController.updateXlsxCurations);
+
+router.route('/xml-generator')
+  .post(isAuth, xlsxController.getXlsxCurations);
+
+router.route('/xml-submit')
+  .post(isAuth, xlsxController.getXlsxCurations);
+
+module.exports = router;

--- a/resfulservice/src/server.js
+++ b/resfulservice/src/server.js
@@ -8,6 +8,7 @@ const { useServer: useWsServer } = require('graphql-ws/lib/use/ws');
 const { globalMiddleWare, log } = require('./middlewares');
 const adminRoutes = require('./routes/admin');
 const authRoutes = require('./routes/authService');
+const curationRoutes = require('./routes/curation');
 const elasticSearch = require('./utils/elasticSearch');
 const fileRoutes = require('./routes/files');
 const invalidRoutes = require('./routes/invalid');
@@ -26,6 +27,7 @@ globalMiddleWare(app);
 elasticSearch.ping(log);
 
 app.use('/admin', adminRoutes);
+app.use('/curate', curationRoutes);
 app.use('/secure', authRoutes);
 app.use('/files', fileRoutes);
 app.use('/knowledge', knowledgeRoutes);

--- a/resfulservice/src/utils/xlsxFileManager.js
+++ b/resfulservice/src/utils/xlsxFileManager.js
@@ -1,0 +1,6 @@
+const readXlsxFile = require('read-excel-file/node');
+
+exports.xlsxFileReader = async (path, sheetName) => {
+  const sheetData = await readXlsxFile(path, { sheet: sheetName });
+  return sheetData;
+};


### PR DESCRIPTION
This task enables ingesting the latest master template spreadsheet, processing it, and converting it into XML.

1. Define new routes for new uploads, update existing submissions, fetch a list of submissions, and fetch a single submission
2. Write new controllers for each of the above endpoints
3. Define mongoDB schema for xlsx curation
4. Generate a JSON response object for FE based on user spreadsheet submission
5. Write a test coverage for these new endpoints

closes #375 