### PR TITLE
feat(#403): Add and fix url query params for XML and chart search

### DIFF
--- a/app/src/components/explorer/Pagination.vue
+++ b/app/src/components/explorer/Pagination.vue
@@ -1,6 +1,6 @@
 <template>
-  <div>
-    <div v-if="tpages > 1" class="explorer_page-nav u_margin-top-med viz-pagination-width-mod u_margin-bottom-small">
+  <div class="explorer_page-nav u_margin-top-med viz-pagination-width-mod u_margin-bottom-small">
+    <div v-if="tpages > 1">
       <button
         @click.prevent="goToBeginning"
         v-if="rowNumber > 1" :disabled="rowNumber < 1"
@@ -35,6 +35,14 @@ export default {
       pageInput: this.cpage,
       offset: 0,
       rowNumber: 1
+    }
+  },
+  watch: {
+    // Necessary for when searching changes the page number
+    cpage (newValue, oldValues) {
+      if ((newValue !== oldValues) && this.pageExists(newValue)) {
+        this.pageInput = newValue
+      }
     }
   },
   mounted () {

--- a/app/src/mixins/explorerQueryParams.js
+++ b/app/src/mixins/explorerQueryParams.js
@@ -1,0 +1,58 @@
+export default {
+  watch: {
+    '$route.query' (newValue, oldValues) {
+      if (newValue !== oldValues) {
+        this.loadParams(newValue)
+      }
+    },
+    pageSize (newValue, oldValue) {
+      if (newValue !== oldValue) {
+        this.checkPageSize(newValue)
+        this.updateParamsAndCall(true)
+      }
+    }
+  },
+  methods: {
+    async loadParams (query) {
+      this.pageNumber = parseInt(query.page) ? +query.page : 1
+      if (this.pageSize) { parseInt(query.size) ? this.checkPageSize(+query.size) : this.checkPageSize(20) }
+      query.q ? this.updateSearchWord(query.q) : this.updateSearchWord('')
+      await this.updateParamsAndCall()
+    },
+    async updateParamsAndCall (pushNewRoute = false) {
+      this.searchEnabled = !!this.searchWord
+      if (pushNewRoute) {
+        const query = {
+          page: this.pageNumber
+        }
+        if (this.pageSize) { query.size = this.pageSize }
+        if (this.searchWord) { query.q = this.searchWord }
+        if (this.filter) { query.type = this.filter }
+        this.$router.push({ query })
+      }
+      await this.localSearchMethod()
+    },
+    async loadPrevNextImage (event) {
+      this.pageNumber = event
+      await this.updateParamsAndCall(true)
+    },
+    updateSearchWord (searchWord) {
+      if (!searchWord && !searchWord.length > 0) this.searchEnabled = false
+      this.searchWord = searchWord
+    },
+    async resetSearch (type) {
+      this.renderText = `Showing all ${type}`
+      await this.$router.replace({ query: {} })
+      return await this.loadParams({})
+    },
+    checkPageSize (pageSize) {
+      if (!pageSize || (pageSize && pageSize < 1)) {
+        this.pageSize = 20
+      } else if (pageSize && pageSize > 50) {
+        this.pageSize = 20
+      } else {
+        this.pageSize = pageSize
+      }
+    }
+  }
+}

--- a/app/src/pages/explorer/Gallery.vue
+++ b/app/src/pages/explorer/Gallery.vue
@@ -81,7 +81,7 @@
       <pagination
         :cpage="page"
         :tpages="totalPages"
-        @go-to-page="loadItems($event)"
+        @go-to-page="loadPrevNextImage($event)"
       />
     </div>
     <dialogbox :active="dialogBoxActive" :minWidth="dialog.minWidth">
@@ -122,15 +122,17 @@ import defaultImg from '@/assets/img/rdf_flyer.svg'
 import { toChartId } from '@/modules/vega-chart'
 import { mapGetters, mapActions, mapMutations } from 'vuex'
 import reducer from '@/mixins/reduce'
+import explorerQueryParams from '@/mixins/explorerQueryParams'
 
 export default {
   name: 'viz-grid',
-  mixins: [reducer],
+  mixins: [reducer, explorerQueryParams],
   data () {
     return {
       loading: true,
       loadError: false,
       otherArgs: null,
+      pageNumber: 1,
       defaultImg,
       baseUrl: `${window.location.origin}/api/knowledge/images?uri=`,
       dialog: {
@@ -184,6 +186,9 @@ export default {
     bookmark () {
       // TODO
     },
+    async localSearchMethod () {
+      await this.loadItems(this.pageNumber)
+    },
     async loadItems (page = 1) {
       this.loading = true
       await this.$store.dispatch('explorer/gallery/loadItems', { page })
@@ -194,7 +199,12 @@ export default {
     }
   },
   async mounted () {
-    await this.loadItems()
+    const query = this.$route.query
+    if (query?.page) {
+      await this.loadParams(this.$route.query, false)
+    } else {
+      await this.loadItems()
+    }
   },
   watch: {
     newChartExist () {

--- a/app/src/pages/explorer/image/Image.vue
+++ b/app/src/pages/explorer/image/Image.vue
@@ -33,7 +33,7 @@
             <button v-if="searchEnabled"
               type="submit"
               class="btn btn--primary btn--noradius search_box_form_btn mid-first-li display-text u--margin-pos"
-              @click.prevent="resetSearch"
+              @click.prevent="clearForm()"
             >
             Clear Search
             </button>
@@ -115,9 +115,10 @@ import spinner from '@/components/Spinner'
 import pagination from '@/components/explorer/Pagination'
 import { IMAGES_QUERY, SEARCH_IMAGES_QUERY } from '@/modules/gql/image-gql'
 import reducer from '@/mixins/reduce'
+import explorerQueryParams from '@/mixins/explorerQueryParams'
 export default {
   name: 'ImageGallery',
-  mixins: [reducer],
+  mixins: [reducer, explorerQueryParams],
   data () {
     return {
       baseUrl: window.location.origin,
@@ -148,35 +149,16 @@ export default {
         this.renderText = `Showing ${newValue.type}: ${newValue.value}`
         this.searchEnabled = true
         this.pageSize = newValue.pageSize || this.pageSize
-        return this.refetchApollo()
+        return this.localSearchMethod()
       } else {
         this.searchEnabled = false
         this.pageSize = newValue.pageSize || this.pageSize
-        return this.refetchApollo()
+        return this.localSearchMethod()
       }
-    },
-    '$route.query' (newValue, oldValues) {
-      this.pageNumber = parseInt(newValue.page) || 1
-      this.pageSize = parseInt(newValue.size) || 20
-      this.filter = newValue.type || ''
-      this.searchWord = newValue.q || ''
-      this.dispatchSearch()
-    },
-    // Limit page size for now
-    pageSize (newValue, oldValue) {
-      this.checkPageSize(newValue)
-      this.loadPrevNextImage(this.pageNumber)
     }
   },
   methods: {
-    loadPrevNextImage (event) {
-      this.pageNumber = event
-      if (!this.searchEnabled) {
-        return this.changeRoute(event, this.pageSize)
-      }
-      this.changeRoute(event, this.pageSize, this.filter, this.searchWord)
-    },
-    refetchApollo () {
+    localSearchMethod () {
       this.error = ''
       if (this.searchEnabled) {
         this.$apollo.queries.images.skip = true
@@ -188,7 +170,7 @@ export default {
         this.$apollo.queries.images.refetch()
       }
     },
-    submitSearch () {
+    async submitSearch () {
       if (!this.searchWord || !this.filter) {
         return this.$store.commit('setSnackbar', {
           message: 'Enter a search term and select a filter type',
@@ -197,33 +179,18 @@ export default {
       }
       this.pageNumber = 1
       this.dispatchSearch()
-      this.changeRoute(this.pageNumber, this.pageSize, this.filter, this.searchWord)
-    },
-    async resetSearch () {
-      this.$router.replace({ query: null })
-      this.searchImages = []
-      this.renderText = 'Showing all images'
+      return await this.updateParamsAndCall(true)
     },
     async dispatchSearch () {
       await this.$store.commit('explorer/setSelectedFacetFilterMaterialsValue',
         { type: this.filter, value: this.searchWord, size: this.pageSize })
     },
-    changeRoute (page = 1, size = 20, filter = '', query = '') {
-      const curQuery = this.$route.query
-      // Don't push change if same route to avoid error
-      if (curQuery.page === page && curQuery.size === size && curQuery.type === filter && curQuery.q === query) {
-        this.refetchApollo()
-      } else if (filter === '' || query === '') {
-        if (curQuery.page === page && curQuery.size === size) return this.refetchApollo()
-        this.$router.push({ query: { page, size } })
-      } else this.$router.push({ query: { page, size, type: filter, q: query } })
-    },
-    checkPageSize (page) {
-      if (page > 20) {
-        this.pageSize = 20
-      } else if (page < 1) {
-        this.pageSize = 1
-      }
+    clearForm () {
+      this.resetSearch('images')
+      this.searchImages = []
+      this.filter = ''
+      this.searchWord = ''
+      this.dispatchSearch()
     }
   },
   created () {
@@ -239,7 +206,7 @@ export default {
       this.searchEnabled = true
       this.filter = this.imageSearch?.type
       this.searchWord = this.imageSearch?.value
-      this.refetchApollo()
+      this.localSearchMethod()
     } else {
       this.searchEnabled = false
       this.dispatchSearch()


### PR DESCRIPTION
Enables going back to the same search results for XMLs and charts
I tried as much as possible to migrate out the existing logic from both images and XML into a single mixin (explorerQueryParams.js)
- Some code was duplicated between images and XML, tried to standardize these
- Some code was a little too customized for the search method, so left those in their original components
- Charts use a different query method than XMLs and images, so that one only uses page number and not the other params

There was also a bug in Pagination.vue where the UI for the selected page number wouldn't update if the prop was externally modified by bypassing its internal methods, so this PR fixes that

closes #403 