### PR TITLE
Dataset UI updates for SDD results page

### DIFF
--- a/app/src/router/module/explorer.js
+++ b/app/src/router/module/explorer.js
@@ -214,7 +214,7 @@ const explorerRoutes = [
   {
     path: 'dataset/:id',
     name: 'DatasetVisualizer',
-    component: () => import('@/pages/explorer/dataset/DatasetViewWhyis.vue'),
+    component: () => import('@/pages/explorer/dataset/Dataset.vue'),
     props: true,
     meta: { requiresAuth: false }
   }

--- a/app/src/store/modules/explorer/actions.js
+++ b/app/src/store/modules/explorer/actions.js
@@ -53,11 +53,10 @@ export default {
     })
 
     if (response?.statusText !== 'OK') {
-      const snackbar = {
-        message: response.message || 'Something went wrong while fetching dataset',
-        duration: 5000
-      }
-      return context.commit('setSnackbar', snackbar, { root: true })
+      const error = new Error(
+        response?.message || 'Something went wrong while fetching dataset'
+      )
+      throw error
     }
 
     const responseData = await response.json()


### PR DESCRIPTION
- Fixes loading spinner
-  Loads datasets that don’t have complete data (specifically malformed ORCID)
-  For distribution list, shows label (shorter name) instead of full link
-  Renames to Dataset.vue since has its own folder
-  Shows "Click to download" file for distributions like in XML gallery
-  Centers date on metadata page
-  Replaces image alt with Title and "Image"

closes #417 