### PR TITLE
#428 update tools page

### DIFF
--- a/app/src/assets/css/modules/_resetvuematerial.scss
+++ b/app/src/assets/css/modules/_resetvuematerial.scss
@@ -127,6 +127,13 @@
             display: none !important;
             visibility: hidden !important;
         }
+
+        & > a {
+            color: $primary !important;
+            &:hover{
+                text-decoration: none !important;
+            }
+        }
     }
 }
 .md-menu-content {

--- a/app/src/assets/css/modules/_resetvuematerial.scss
+++ b/app/src/assets/css/modules/_resetvuematerial.scss
@@ -123,6 +123,10 @@
             margin-bottom: 1rem;
         }
 
+        &-tall {
+            height: 38rem !important;
+        }
+
         &::after {
             display: none !important;
             visibility: hidden !important;

--- a/app/src/components/Drawer.vue
+++ b/app/src/components/Drawer.vue
@@ -66,9 +66,11 @@
           <router-link :to="'/nm/tools/module_homepage'" v-slot="{navigate, href}" custom>
             <md-list-item :href="href" @click="navigate"  class="md-inset">Module Tools</md-list-item>
           </router-link>
-          <router-link :to="'/nm/tools/simtools'" v-slot="{navigate, href}" custom>
+          <!-- TODO 7/21/2023: The old Polymerizer is no longer functional.
+            The old stewards of the tool are in the process of recovery, but there is currently no ETA. -->
+          <!-- <router-link :to="'/nm/tools/simtools'" v-slot="{navigate, href}" custom>
             <md-list-item :href="href" @click="navigate"  class="md-inset">Simulation Tools</md-list-item>
-          </router-link>
+          </router-link> -->
           <router-link :to="'/nm/tools/chemprops'" v-slot="{navigate, href}" custom>
             <md-list-item :href="href" @click="navigate"  class="md-inset">ChemProps</md-list-item>
           </router-link>

--- a/app/src/components/Drawer.vue
+++ b/app/src/components/Drawer.vue
@@ -63,22 +63,14 @@
         <md-icon class="utility-navfonticon">handyman</md-icon>
         <span class="md-list-item-text utility-navfont">Tools</span>
         <md-list slot="md-expand">
-          <router-link :to="'/nm/tools/module_homepage'" v-slot="{navigate, href}" custom>
-            <md-list-item :href="href" @click="navigate"  class="md-inset">Module Tools</md-list-item>
-          </router-link>
-          <!-- TODO 7/21/2023: The old Polymerizer is no longer functional.
-            The old stewards of the tool are in the process of recovery, but there is currently no ETA. -->
-          <!-- <router-link :to="'/nm/tools/simtools'" v-slot="{navigate, href}" custom>
-            <md-list-item :href="href" @click="navigate"  class="md-inset">Simulation Tools</md-list-item>
-          </router-link> -->
-          <router-link :to="'/nm/tools/chemprops'" v-slot="{navigate, href}" custom>
-            <md-list-item :href="href" @click="navigate"  class="md-inset">ChemProps</md-list-item>
+          <router-link :to="'/explorer/tools'" v-slot="{navigate, href}" custom>
+            <md-list-item :href="href" @click="navigate"  class="md-inset">Module & Simulation Tools</md-list-item>
           </router-link>
           <router-link :to="'/nm/tools/plot-curation'" v-slot="{navigate, href}" custom>
             <md-list-item :href="href" @click="navigate"  class="md-inset">Easy CSV Plotter</md-list-item>
           </router-link>
           <router-link :to="'/explorer/sparql'" v-slot="{navigate, href}" custom>
-            <md-list-item :href="href" @click="navigate"  class="md-inset">Sparql Query Tool</md-list-item>
+            <md-list-item :href="href" @click="navigate"  class="md-inset">Sparql Query Interface</md-list-item>
           </router-link>
         </md-list>
       </md-list-item>

--- a/app/src/components/accordion.vue
+++ b/app/src/components/accordion.vue
@@ -3,7 +3,10 @@
   <div @click="toggleOpen">
     <md-toolbar :class="dense ? 'md-dense' :'md-toolbar_adjust u--padding-zero'">
       <div class="u_display-flex accordion-toolbar-row viz-sample__header">
-        <h4 v-if="dense" class="md-subheader">{{title}}</h4>
+        <div v-if="customTitle">
+          <slot name="custom_title"></slot>
+        </div>
+        <h4 v-else-if="dense" class="md-subheader">{{title}}</h4>
         <h3 v-else class="md-title">{{title}}</h3>
         <div class="accordion-icons">
           <md-icon v-show="!open">
@@ -35,6 +38,10 @@ export default Vue.component('accordion', {
       type: String
     },
     dense: {
+      type: Boolean,
+      default: () => false
+    },
+    customTitle: {
       type: Boolean,
       default: () => false
     }

--- a/app/src/components/explorer/Header.vue
+++ b/app/src/components/explorer/Header.vue
@@ -31,6 +31,7 @@
           <md-tab class="_menutabs" to="/explorer" id="tab-home" md-label="Search" exact> </md-tab>
           <md-tab class="_menutabs" to="/explorer/visualization" id="tab-visualization" md-label="Visualization"> </md-tab>
           <md-tab class="_menutabs" to="/explorer/curate" id="tab-curate" md-label="Curate"> </md-tab>
+          <md-tab class="_menutabs" to="/explorer/tools" id="tab-tools" md-label="Tools"> </md-tab>
           <md-tab class="_menutabs" to="/explorer/parameterized_query" id="tab-query" md-label="Parameterized Query" exact> </md-tab>
           <md-tab class="_menutabs" to="/explorer/sparql" id="tab-sparql" md-label="SPARQL Query" exact> </md-tab>
         </md-tabs>

--- a/app/src/components/nanomine/PageHeader.vue
+++ b/app/src/components/nanomine/PageHeader.vue
@@ -84,7 +84,9 @@
                                 <div class="nav_menu--siblings">
                                     <router-link to="/explorer/sparql" class="nav_menu--siblings-lists"><a>Sparql Query</a></router-link>
                                     <router-link to="/nm/tools/module_homepage" class="nav_menu--siblings-lists"><a>Module Tools</a></router-link>
-                                    <router-link to="/nm/tools/simtools" class="nav_menu--siblings-lists"><a>Simulation Tools</a></router-link>
+                                    <!-- TODO 7/21/2023: The old Polymerizer is no longer functional.
+                                      The old stewards of the tool are in the process of recovery, but there is currently no ETA. -->
+                                    <!-- <router-link to="/nm/tools/simtools" class="nav_menu--siblings-lists"><a>Simulation Tools</a></router-link> -->
                                     <router-link to="/nm/tools/chemprops" class="nav_menu--siblings-lists"><a>ChemProps</a></router-link>
                                     <router-link to="/nm/tools/plot-curation" class="nav_menu--siblings-lists"><a>Easy CSV Plotter</a></router-link>
                                     <router-link to="" @click.native="loadApiDocs" class="nav_menu--siblings-lists"><a>Api Docs</a></router-link>

--- a/app/src/components/nanomine/PageHeader.vue
+++ b/app/src/components/nanomine/PageHeader.vue
@@ -83,13 +83,9 @@
                                 <a class="u--default-size nav_menu--handler" href="#">Tools</a>
                                 <div class="nav_menu--siblings">
                                     <router-link to="/explorer/sparql" class="nav_menu--siblings-lists"><a>Sparql Query</a></router-link>
-                                    <router-link to="/nm/tools/module_homepage" class="nav_menu--siblings-lists"><a>Module Tools</a></router-link>
-                                    <!-- TODO 7/21/2023: The old Polymerizer is no longer functional.
-                                      The old stewards of the tool are in the process of recovery, but there is currently no ETA. -->
-                                    <!-- <router-link to="/nm/tools/simtools" class="nav_menu--siblings-lists"><a>Simulation Tools</a></router-link> -->
-                                    <router-link to="/nm/tools/chemprops" class="nav_menu--siblings-lists"><a>ChemProps</a></router-link>
+                                    <router-link to="/explorer/tools" class="nav_menu--siblings-lists"><a>Module & Simulation Tools</a></router-link>
                                     <router-link to="/nm/tools/plot-curation" class="nav_menu--siblings-lists"><a>Easy CSV Plotter</a></router-link>
-                                    <router-link to="" @click.native="loadApiDocs" class="nav_menu--siblings-lists"><a>Api Docs</a></router-link>
+                                    <router-link to="" @click.native="loadApiDocs" class="nav_menu--siblings-lists"><a>API Docs</a></router-link>
                                 </div>
                             </div>
                         </li>

--- a/app/src/pages/explorer/Tools.vue
+++ b/app/src/pages/explorer/Tools.vue
@@ -46,7 +46,7 @@
                     <div class="u_margin-bottom-small"> All 'Characterization and Reconstruction' algorithms work with binarized images only.</div>
                     <div class="md-layout u_display-flex md-layout-responsive u_margin-top-med">
                         <div class="md-layout-item md-layout-item_card">
-                            <router-link to="" v-slot="{navigate, href}" custom>
+                            <router-link to="/nm/tools/Otsu" v-slot="{navigate, href}" custom>
                                 <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">compare</md-icon>
                                     <span class="explorer_page-nav-card_text">Otsu's Method</span>
@@ -57,7 +57,7 @@
                         </div>
 
                         <div class="md-layout-item md-layout-item_card">
-                            <router-link to="" v-slot="{navigate, href}" custom>
+                            <router-link to="/nm/tools/Niblack" v-slot="{navigate, href}" custom>
                                 <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">compare</md-icon>
                                     <span class="explorer_page-nav-card_text">Niblack's Method</span>
@@ -76,9 +76,22 @@
                     <template #custom_title>
                         <h2 class="visualize_header-h1" style="margin-bottom:0;">Microstructure Characterization</h2>
                     </template>
+                    <div class="u_margin-top-small">
+                        Microstructure Characterization refers to a statistical quantification of morphology.
+                        It essentially converts multi-dimensional microstructure recorded in images into a
+                        set of functions (aka features/descriptors/predictors) that encode significant
+                        morphological details.
+                        The functions obtained as a result are useful in developing
+                        insights on structure - property relationships and serve as the basis for reconstruction
+                        algorithms.
+                    </div>
+                    <div class="u_margin-bottom-small">
+                        Upload a binarized microstructure image / set of images and obtain
+                        characterization data of your choice.
+                    </div>
                     <div class="md-layout u_display-flex md-layout-responsive u_margin-top-med">
                         <div class="md-layout-item md-layout-item_card">
-                            <router-link to="" v-slot="{navigate, href}" custom>
+                            <router-link to="/nm/tools/IntelligentCharacterize" v-slot="{navigate, href}" custom>
                                 <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">image_search</md-icon>
                                     <span class="explorer_page-nav-card_text" style="text-align: center">Intelligent Characterization</span>
@@ -87,7 +100,7 @@
                             </router-link>
                         </div>
                         <div class="md-layout-item md-layout-item_card">
-                            <router-link to="" v-slot="{navigate, href}" custom>
+                            <router-link to="/nm/tools/CorrelationCharacterize" v-slot="{navigate, href}" custom>
                                 <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
                                     <span class="explorer_page-nav-card_text">Correlation Functions</span>
@@ -97,7 +110,7 @@
                             </router-link>
                         </div>
                         <div class="md-layout-item md-layout-item_card">
-                            <router-link to="" v-slot="{navigate, href}" custom>
+                            <router-link to="/nm/tools/DescriptorCharacterize" v-slot="{navigate, href}" custom>
                                 <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
                                     <span class="explorer_page-nav-card_text">Physical Descriptors</span>
@@ -107,7 +120,7 @@
                             </router-link>
                         </div>
                         <div class="md-layout-item md-layout-item_card">
-                            <router-link to="" v-slot="{navigate, href}" custom>
+                            <router-link to="/nm/tools/SDFCharacterized" v-slot="{navigate, href}" custom>
                                 <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
                                     <span class="explorer_page-nav-card_text">Spectral Density</span>
@@ -124,9 +137,17 @@
                     <template #custom_title>
                         <h2 class="visualize_header-h1" style="margin-bottom:0;">Microstructure Reconstruction</h2>
                     </template>
+                    <div class="u_margin-top-small"> Reconstruction involves constructing a statistically equivalent microstructure
+                        image given some statistical characterization. In most cases, reconstruction is
+                        cast as an optimization problem; with the goal of matching characteristics of
+                        reconstructed image to that of input image.
+                    </div>  <div class="u_margin-bottom-small">
+                        In this section, you can upload a binary microstructure image / set of images
+                        and obtain 2D/3D reconstructions using method of your choice.
+                    </div>
                     <div class="md-layout u_display-flex md-layout-responsive u_margin-top-med">
                         <div class="md-layout-item md-layout-item_card">
-                            <router-link to="" v-slot="{navigate, href}" custom>
+                            <router-link to="/nm/tools/CorrelationReconstruct" v-slot="{navigate, href}" custom>
                                 <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
                                     <span class="explorer_page-nav-card_text">Correlation Functions</span>
@@ -136,7 +157,7 @@
                             </router-link>
                         </div>
                         <div class="md-layout-item md-layout-item_card">
-                            <router-link to="" v-slot="{navigate, href}" custom>
+                            <router-link to="/nm/tools/DescriptorReconstruct" v-slot="{navigate, href}" custom>
                                 <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
                                     <span class="explorer_page-nav-card_text">Physical Descriptors</span>
@@ -146,7 +167,7 @@
                             </router-link>
                         </div>
                         <div class="md-layout-item md-layout-item_card">
-                            <router-link to="" v-slot="{navigate, href}" custom>
+                            <router-link to="/nm/tools/SDFReconstruct" v-slot="{navigate, href}" custom>
                                 <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
                                     <span class="explorer_page-nav-card_text">Spectral Density</span>
@@ -156,14 +177,14 @@
                             </router-link>
                         </div>
                         <div class="md-layout-item md-layout-item_card">
-                            <router-link to="" v-slot="{navigate, href}" custom>
-                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                            <a href="https://ideal.mech.northwestern.edu/research/software/download/"  target="_blank">
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card">
                                     <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
                                     <span class="explorer_page-nav-card_text">Transfer Learning</span>
                                     <p class="md-layout-item_para md-layout-item_para_fl">Short description of Transfer Learning
                                     </p>
                                 </div>
-                            </router-link>
+                            </a>
                         </div>
                     </div>
                     </accordion>

--- a/app/src/pages/explorer/Tools.vue
+++ b/app/src/pages/explorer/Tools.vue
@@ -1,0 +1,184 @@
+<template>
+	<div>
+		<div class="section_teams">
+			<div class="curate">
+				<div>
+                    <h2 class="visualize_header-h1">Tools</h2>
+                    <div class="md-layout u_display-flex md-layout-responsive">
+                        <div class="md-layout-item md-layout-item_card">
+                            <router-link to="/explorer/tools/dynamfit" v-slot="{navigate, href}" custom>
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                                    <md-icon class="explorer_page-nav-card_icon">stacked_line_chart</md-icon>
+                                    <span class="explorer_page-nav-card_text">DynamFit</span>
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description here about what DynamFit does.</p>
+                                </div>
+                            </router-link>
+                        </div>
+                        <div class="md-layout-item md-layout-item_card">
+                            <router-link to="" v-slot="{navigate, href}" custom>
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                                    <md-icon class="explorer_page-nav-card_icon">manage_search</md-icon>
+                                    <span class="explorer_page-nav-card_text">ChemProps</span>
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of ChemProps.</p>
+                                </div>
+                            </router-link>
+                        </div>
+                        <div class="md-layout-item md-layout-item_card">
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card">
+                                    <md-icon class="explorer_page-nav-card_icon">grain</md-icon>
+                                    <span class="explorer_page-nav-card_text" style="text-align: center">Polymerizer</span>
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Polymerizer.</p>
+                                </div>
+                        </div>
+                    </div>
+                </div>
+                <div class="u_margin-top-med">
+                <accordion :startOpen="false" :customTitle="true" :title="'Image Binarization'">
+                    <template #custom_title> 
+                        <h2 class="visualize_header-h1" style="margin-bottom:0;">Image Binarization</h2>
+                    </template>
+                  <div class="u_margin-top-small">
+                    <div> Binarization is the process of converting a micrograph to a black and white 
+                        image (assuming there are only 2 phases) by removing noise and thus simplifying 
+                        its analysis.
+                    </div>
+                    <div class="u_margin-bottom-small"> All 'Characterization and Reconstruction' algorithms work with binarized images only.</div>
+                    <div class="md-layout u_display-flex md-layout-responsive u_margin-top-med">
+                        <div class="md-layout-item md-layout-item_card">
+                            <router-link to="" v-slot="{navigate, href}" custom>
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                                    <md-icon class="explorer_page-nav-card_icon">compare</md-icon>
+                                    <span class="explorer_page-nav-card_text">Otsu's Method</span>
+                                    <p class="md-layout-item_para md-layout-item_para_fl"> Works well for relatively 
+                                        noise free images having significant contrast between filler and matrix material.</p>
+                                </div>
+                            </router-link>
+                        </div>
+
+                        <div class="md-layout-item md-layout-item_card">
+                            <router-link to="" v-slot="{navigate, href}" custom>
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                                    <md-icon class="explorer_page-nav-card_icon">compare</md-icon>
+                                    <span class="explorer_page-nav-card_text">Niblack's Method</span>
+                                    <p class="md-layout-item_para md-layout-item_para_fl">
+                                        Works well for gray-level images with low contrast between filler and matrix material.
+                                    </p>
+                                </div>
+                            </router-link>
+                        </div>
+                    </div>
+                  </div>
+                </accordion>
+                </div>
+                <div class="u_margin-top-med">
+                <accordion :startOpen="false" :customTitle="true" :title="'Microstructure Characterization'">
+                    <template #custom_title> 
+                        <h2 class="visualize_header-h1" style="margin-bottom:0;">Microstructure Characterization</h2>
+                    </template>
+                    <div class="md-layout u_display-flex md-layout-responsive u_margin-top-med">
+                        <div class="md-layout-item md-layout-item_card">
+                            <router-link to="" v-slot="{navigate, href}" custom>
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                                    <md-icon class="explorer_page-nav-card_icon">image_search</md-icon>
+                                    <span class="explorer_page-nav-card_text" style="text-align: center">Intelligent Characterization</span>
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Intelligent Characterization.</p>
+                                </div>
+                            </router-link>
+                        </div>
+                        <div class="md-layout-item md-layout-item_card">
+                            <router-link to="" v-slot="{navigate, href}" custom>
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                                    <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
+                                    <span class="explorer_page-nav-card_text">Correlation Functions</span>
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Correlation Functions
+                                    </p>
+                                </div>
+                            </router-link>
+                        </div>
+                        <div class="md-layout-item md-layout-item_card">
+                            <router-link to="" v-slot="{navigate, href}" custom>
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                                    <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
+                                    <span class="explorer_page-nav-card_text">Physical Descriptors</span>
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Physical Descriptors
+                                    </p>
+                                </div>
+                            </router-link>
+                        </div>
+                        <div class="md-layout-item md-layout-item_card">
+                            <router-link to="" v-slot="{navigate, href}" custom>
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                                    <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
+                                    <span class="explorer_page-nav-card_text">Spectral Density</span>
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Spectral Density Function
+                                    </p>
+                                </div>
+                            </router-link>
+                        </div>
+                    </div>
+                </accordion>
+                </div>
+                <div class="u_margin-top-med">
+                    <accordion :startOpen="false" :customTitle="true" :title="'Microstructure Reconstruction'">
+                    <template #custom_title> 
+                        <h2 class="visualize_header-h1" style="margin-bottom:0;">Microstructure Reconstruction</h2>
+                    </template>
+                    <div class="md-layout u_display-flex md-layout-responsive u_margin-top-med">
+                        <div class="md-layout-item md-layout-item_card">
+                            <router-link to="" v-slot="{navigate, href}" custom>
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                                    <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
+                                    <span class="explorer_page-nav-card_text">Correlation Functions</span>
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Correlation Functions
+                                    </p>
+                                </div>
+                            </router-link>
+                        </div>
+                        <div class="md-layout-item md-layout-item_card">
+                            <router-link to="" v-slot="{navigate, href}" custom>
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                                    <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
+                                    <span class="explorer_page-nav-card_text">Physical Descriptors</span>
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Physical Descriptors
+                                    </p>
+                                </div>
+                            </router-link>
+                        </div>
+                        <div class="md-layout-item md-layout-item_card">
+                            <router-link to="" v-slot="{navigate, href}" custom>
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                                    <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
+                                    <span class="explorer_page-nav-card_text">Spectral Density</span>
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Spectral Density Function
+                                    </p>
+                                </div>
+                            </router-link>
+                        </div>
+                        <div class="md-layout-item md-layout-item_card">
+                            <router-link to="" v-slot="{navigate, href}" custom>
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                                    <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
+                                    <span class="explorer_page-nav-card_text">Transfer Learning</span>
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Transfer Learning
+                                    </p>
+                                </div>
+                            </router-link>
+                        </div>
+                    </div>
+                    </accordion>
+                </div>
+			</div>
+		</div>
+	</div>
+</template>
+
+<script>
+import accordion from '@/components/accordion.vue'
+
+export default {
+  name: 'CurateHome',
+  components: {
+    accordion,
+  }
+}
+</script>

--- a/app/src/pages/explorer/Tools.vue
+++ b/app/src/pages/explorer/Tools.vue
@@ -23,13 +23,14 @@
                                 </div>
                             </router-link>
                         </div>
-                        <div class="md-layout-item md-layout-item_card">
+                        <!-- TODO: The original Polymerizer tool is currently out of commision due to an attack on RPI systems  -->
+                        <!-- <div class="md-layout-item md-layout-item_card">
                                 <div class="teams_container explorer_page-nav-card md-layout-item_card">
                                     <md-icon class="explorer_page-nav-card_icon">grain</md-icon>
                                     <span class="explorer_page-nav-card_text" style="text-align: center">Polymerizer</span>
                                     <p class="md-layout-item_para md-layout-item_para_fl">Short description of Polymerizer.</p>
                                 </div>
-                        </div>
+                        </div> -->
                     </div>
                 </div>
                 <div class="u_margin-top-med">

--- a/app/src/pages/explorer/Tools.vue
+++ b/app/src/pages/explorer/Tools.vue
@@ -10,16 +10,16 @@
                                 <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">stacked_line_chart</md-icon>
                                     <span class="explorer_page-nav-card_text">DynamFit</span>
-                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description here about what DynamFit does.</p>
+                                    <p class="md-layout-item_para md-layout-item_para_fl">A sign control algorithm that fits a viscoelastic mastercurve from DMA experiments with a Prony Series.</p>
                                 </div>
                             </router-link>
                         </div>
                         <div class="md-layout-item md-layout-item_card">
-                            <router-link to="" v-slot="{navigate, href}" custom>
+                            <router-link to="/nm/tools/chemprops" v-slot="{navigate, href}" custom>
                                 <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">manage_search</md-icon>
                                     <span class="explorer_page-nav-card_text">ChemProps</span>
-                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of ChemProps.</p>
+                                    <p class="md-layout-item_para md-layout-item_para_fl">A growing polymer name and filler name standardization database.</p>
                                 </div>
                             </router-link>
                         </div>
@@ -90,41 +90,46 @@
                         characterization data of your choice.
                     </div>
                     <div class="md-layout u_display-flex md-layout-responsive u_margin-top-med">
-                        <div class="md-layout-item md-layout-item_card">
+                        <div class="md-layout-item md-layout-item_card md-layout-item_card-tall">
                             <router-link to="/nm/tools/IntelligentCharacterize" v-slot="{navigate, href}" custom>
-                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card md-layout-item_card-tall" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">image_search</md-icon>
                                     <span class="explorer_page-nav-card_text" style="text-align: center">Intelligent Characterization</span>
-                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Intelligent Characterization.</p>
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Analyzes uploaded image(s) to select the most suitable
+                                        characterization method.
+                                    </p>
                                 </div>
                             </router-link>
                         </div>
-                        <div class="md-layout-item md-layout-item_card">
+                        <div class="md-layout-item md-layout-item_card md-layout-item_card-tall">
                             <router-link to="/nm/tools/CorrelationCharacterize" v-slot="{navigate, href}" custom>
-                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card md-layout-item_card-tall" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
                                     <span class="explorer_page-nav-card_text">Correlation Functions</span>
-                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Correlation Functions
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Webtool that evaluates
+                                        autocorrelation, lineal path, cluster and surface correlation.
                                     </p>
                                 </div>
                             </router-link>
                         </div>
-                        <div class="md-layout-item md-layout-item_card">
+                        <div class="md-layout-item md-layout-item_card md-layout-item_card-tall">
                             <router-link to="/nm/tools/DescriptorCharacterize" v-slot="{navigate, href}" custom>
-                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card md-layout-item_card-tall" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
                                     <span class="explorer_page-nav-card_text">Physical Descriptors</span>
-                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Physical Descriptors
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Webtool that evaluates volume fraction,
+                                         number of white phase aggregates, aspect ratio and nearest neighbor distance.
                                     </p>
                                 </div>
                             </router-link>
                         </div>
-                        <div class="md-layout-item md-layout-item_card">
-                            <router-link to="/nm/tools/SDFCharacterized" v-slot="{navigate, href}" custom>
-                                <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
+                        <div class="md-layout-item md-layout-item_card md-layout-item_card-tall">
+                            <router-link to="/nm/tools/SDFCharacterize" v-slot="{navigate, href}" custom>
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card md-layout-item_card-tall" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
                                     <span class="explorer_page-nav-card_text">Spectral Density</span>
-                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Spectral Density Function
+                                    <p class="md-layout-item_para md-layout-item_para_fl">A frequency domain microstructure representation
+                                        where different frequencies represent real space features at different length scales.
                                     </p>
                                 </div>
                             </router-link>
@@ -147,11 +152,23 @@
                     </div>
                     <div class="md-layout u_display-flex md-layout-responsive u_margin-top-med">
                         <div class="md-layout-item md-layout-item_card">
+                            <a href="https://ideal.mech.northwestern.edu/research/software/download/"  target="_blank">
+                                <div class="teams_container explorer_page-nav-card md-layout-item_card">
+                                    <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
+                                    <span class="explorer_page-nav-card_text">Transfer Learning</span>
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Captures spatial correlations for microstructure
+                                        reconstruction by leveraging the superior capabilities of deep convolution networks. Click to request access link.
+                                    </p>
+                                </div>
+                            </a>
+                        </div>
+                        <div class="md-layout-item md-layout-item_card">
                             <router-link to="/nm/tools/CorrelationReconstruct" v-slot="{navigate, href}" custom>
                                 <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
                                     <span class="explorer_page-nav-card_text">Correlation Functions</span>
-                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Correlation Functions
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Employs the Yeong-Torquato method
+                                        to match the correlation function of 2D reconstructed image to that of 2D input image.
                                     </p>
                                 </div>
                             </router-link>
@@ -161,7 +178,8 @@
                                 <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
                                     <span class="explorer_page-nav-card_text">Physical Descriptors</span>
-                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Physical Descriptors
+                                    <p class="md-layout-item_para md-layout-item_para_fl">
+                                        Webtool that creates a 3D reconstruction from the 2D input image.
                                     </p>
                                 </div>
                             </router-link>
@@ -171,20 +189,11 @@
                                 <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
                                     <span class="explorer_page-nav-card_text">Spectral Density</span>
-                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Spectral Density Function
+                                    <p class="md-layout-item_para md-layout-item_para_fl">Reconstruction method that involves level-cutting
+                                        a Gaussian Random Field with the same SDF as the input image.
                                     </p>
                                 </div>
                             </router-link>
-                        </div>
-                        <div class="md-layout-item md-layout-item_card">
-                            <a href="https://ideal.mech.northwestern.edu/research/software/download/"  target="_blank">
-                                <div class="teams_container explorer_page-nav-card md-layout-item_card">
-                                    <md-icon class="explorer_page-nav-card_icon">ssid_chart</md-icon>
-                                    <span class="explorer_page-nav-card_text">Transfer Learning</span>
-                                    <p class="md-layout-item_para md-layout-item_para_fl">Short description of Transfer Learning
-                                    </p>
-                                </div>
-                            </a>
                         </div>
                     </div>
                     </accordion>

--- a/app/src/pages/explorer/Tools.vue
+++ b/app/src/pages/explorer/Tools.vue
@@ -34,12 +34,12 @@
                 </div>
                 <div class="u_margin-top-med">
                 <accordion :startOpen="false" :customTitle="true" :title="'Image Binarization'">
-                    <template #custom_title> 
+                    <template #custom_title>
                         <h2 class="visualize_header-h1" style="margin-bottom:0;">Image Binarization</h2>
                     </template>
                   <div class="u_margin-top-small">
-                    <div> Binarization is the process of converting a micrograph to a black and white 
-                        image (assuming there are only 2 phases) by removing noise and thus simplifying 
+                    <div> Binarization is the process of converting a micrograph to a black and white
+                        image (assuming there are only 2 phases) by removing noise and thus simplifying
                         its analysis.
                     </div>
                     <div class="u_margin-bottom-small"> All 'Characterization and Reconstruction' algorithms work with binarized images only.</div>
@@ -49,7 +49,7 @@
                                 <div class="teams_container explorer_page-nav-card md-layout-item_card" :href="href" @click="navigate">
                                     <md-icon class="explorer_page-nav-card_icon">compare</md-icon>
                                     <span class="explorer_page-nav-card_text">Otsu's Method</span>
-                                    <p class="md-layout-item_para md-layout-item_para_fl"> Works well for relatively 
+                                    <p class="md-layout-item_para md-layout-item_para_fl"> Works well for relatively
                                         noise free images having significant contrast between filler and matrix material.</p>
                                 </div>
                             </router-link>
@@ -72,7 +72,7 @@
                 </div>
                 <div class="u_margin-top-med">
                 <accordion :startOpen="false" :customTitle="true" :title="'Microstructure Characterization'">
-                    <template #custom_title> 
+                    <template #custom_title>
                         <h2 class="visualize_header-h1" style="margin-bottom:0;">Microstructure Characterization</h2>
                     </template>
                     <div class="md-layout u_display-flex md-layout-responsive u_margin-top-med">
@@ -120,7 +120,7 @@
                 </div>
                 <div class="u_margin-top-med">
                     <accordion :startOpen="false" :customTitle="true" :title="'Microstructure Reconstruction'">
-                    <template #custom_title> 
+                    <template #custom_title>
                         <h2 class="visualize_header-h1" style="margin-bottom:0;">Microstructure Reconstruction</h2>
                     </template>
                     <div class="md-layout u_display-flex md-layout-responsive u_margin-top-med">
@@ -178,7 +178,7 @@ import accordion from '@/components/accordion.vue'
 export default {
   name: 'CurateHome',
   components: {
-    accordion,
+    accordion
   }
 }
 </script>

--- a/app/src/pages/explorer/tools/ToolsBase.vue
+++ b/app/src/pages/explorer/tools/ToolsBase.vue
@@ -1,0 +1,3 @@
+<template>
+<router-view />
+</template>

--- a/app/src/pages/explorer/tools/dynamfit/DynamFit.vue
+++ b/app/src/pages/explorer/tools/dynamfit/DynamFit.vue
@@ -2,7 +2,7 @@
   <div class="explorer_page_header">
     <h1 class="visualize_header-h1 u_margin-top-med u_centralize_text">DynamFit</h1>
     <div>
-        Put html content here!
+      <!-- Put html content here -->
     </div>
   </div>
 </template>

--- a/app/src/pages/explorer/tools/dynamfit/DynamFit.vue
+++ b/app/src/pages/explorer/tools/dynamfit/DynamFit.vue
@@ -1,0 +1,22 @@
+<template>
+  <div class="explorer_page_header">
+    <h1 class="visualize_header-h1 u_margin-top-med u_centralize_text">DynamFit</h1>
+    <div>
+        Put html content here!
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'DynamFit',
+  data () {
+    return {
+      // Put any needed component-level data here
+    }
+  },
+  methods: {
+    // Methods go here
+  }
+}
+</script>

--- a/app/src/pages/nanomine/tools/Polymerizer.vue
+++ b/app/src/pages/nanomine/tools/Polymerizer.vue
@@ -5,11 +5,13 @@
       <img src="@/assets/img/nanomine/prop_simu.png" alt="Propertry Simulation">
     </template>
     <template #actions>
-      <a href="http://reccr.chem.rpi.edu/polymerizer/index.html" target="_blank">
-        <md-button class="md-raised md-primary md-raised">
+      <!-- TODO 7/21/2023: The old Polymerizer is no longer functional.
+        The old stewards of the tool are in the process of recovery, but there is currently no ETA. -->
+      <!-- <a href="http://reccr.chem.rpi.edu/polymerizer/index.html" target="_blank"> -->
+        <md-button class="md-raised md-primary md-raised md-disabled" disabled>
           Launch
         </md-button>
-      </a>
+      <!-- </a> -->
     </template>
     <!-- shared slots -->
     <template #title>

--- a/app/src/router/module/explorer.js
+++ b/app/src/router/module/explorer.js
@@ -34,7 +34,7 @@ const explorerRoutes = [
       {
         path: 'dynamfit',
         name: 'DynamFit',
-        component: () => import('@/pages/explorer/tools/dynamfit/DynamFit.vue'),
+        component: () => import('@/pages/explorer/tools/dynamfit/DynamFit.vue')
       }
     ]
   },

--- a/app/src/router/module/explorer.js
+++ b/app/src/router/module/explorer.js
@@ -22,6 +22,23 @@ const explorerRoutes = [
     meta: { requiresAuth: false }
   },
   {
+    path: 'tools',
+    component: () => import('@/pages/explorer/tools/ToolsBase.vue'),
+    children: [
+      {
+        path: '',
+        name: 'ToolsExplorer',
+        component: () => import('@/pages/explorer/Tools.vue'),
+        meta: { requiresAuth: false }
+      },
+      {
+        path: 'dynamfit',
+        name: 'DynamFit',
+        component: () => import('@/pages/explorer/tools/dynamfit/DynamFit.vue'),
+      }
+    ]
+  },
+  {
     path: 'curate',
     component: () => import('@/pages/explorer/curate/CurateBase.vue'),
     children: [

--- a/app/tests/unit/components/explorer/Header.spec.js
+++ b/app/tests/unit/components/explorer/Header.spec.js
@@ -24,7 +24,7 @@ describe('Header.vue', () => {
   it('renders Menu tabs correctly', async () => {
     expect.assertions(1)
     const menuItems = wrapper.findAll('._menutabs')
-    expect(menuItems.length).toBe(5)
+    expect(menuItems.length).toBe(6)
   })
 
   it('renders Menu tabs only on desktop', async () => {

--- a/app/tests/unit/pages/explorer/Tools.spec.js
+++ b/app/tests/unit/pages/explorer/Tools.spec.js
@@ -1,0 +1,42 @@
+import createWrapper from '../../../jest/script/wrapper'
+import { enableAutoDestroy, RouterLinkStub } from '@vue/test-utils'
+import ExplorerTools from '@/pages/explorer/Tools.vue'
+
+describe('Tools.vue', () => {
+  let wrapper
+  beforeEach(async () => {
+    wrapper = await createWrapper(ExplorerTools, { }, true)
+  })
+
+  enableAutoDestroy(afterEach)
+
+  it('renders tools tab correctly', () => {
+    expect.assertions(1)
+    const catHeader = wrapper.find('.visualize_header-h1')
+    expect(catHeader.exists()).toBe(true)
+  })
+
+  it('renders the right page layout', () => {
+    expect.assertions(4)
+    const sections = wrapper.findAll('div > .section_teams > .curate > div')
+    expect(sections.length).toEqual(4)
+    expect(sections.at(0).attributes().class).toBeUndefined()
+    expect(sections.at(1).attributes().class).toEqual('u_margin-top-med')
+    expect(sections.at(2).attributes().class).toEqual('u_margin-top-med')
+  })
+
+  it('renders curate category headers', () => {
+    expect.assertions(5)
+    const catHeaders = wrapper.findAll('.visualize_header-h1')
+    expect(catHeaders.length).toEqual(4)
+    expect(catHeaders.at(0).text()).toBe('Tools')
+    expect(catHeaders.at(1).text()).toBe('Image Binarization')
+    expect(catHeaders.at(2).text()).toBe('Microstructure Characterization')
+    expect(catHeaders.at(3).text()).toBe('Microstructure Reconstruction')
+  })
+
+  it('renders a card for dynamfit', () => {
+    const sectionItem = wrapper.findAll('.md-layout-item.md-layout-item_card')
+    expect(sectionItem.at(0).findComponent(RouterLinkStub).props().to).toEqual('/explorer/tools/dynamfit')
+  })
+})


### PR DESCRIPTION
This ticket creates a new Tools homepage in Explorer to match updated UI styling
- Updates links in drawer and page header
- Creates an empty template page for the new DynamFit tool migration
- Removes links to Polymerizer tool (currently unavailable)

closes #428 