### PR TITLE
Resolve SDD form errors and add basic unit tests

### DIFF
--- a/app/src/modules/file-list.js
+++ b/app/src/modules/file-list.js
@@ -33,7 +33,15 @@ export default function () {
 class UploadableFile {
   constructor (file) {
     this.file = file
-    this.id = `${file.name}-${file.size}-${file.lastModified}-${file.type}`
+    if (/\s/g.test(file.name)) {
+      this.file = new File([file], file.name.replace(/ /g, '_'), {
+        type: file.type,
+        lastModified: file.lastModified
+      })
+    } else {
+      this.file = file
+    }
+    this.id = `${this.file.name}-${file.size}-${file.lastModified}-${file.type}`
     this.status = 'incomplete'
   }
 }

--- a/app/src/router/module/explorer.js
+++ b/app/src/router/module/explorer.js
@@ -131,7 +131,8 @@ const explorerRoutes = [
   {
     path: 'curate/sdd',
     name: 'CurateSDD',
-    component: () => import('@/pages/explorer/curate/sdd/SddForm.vue')
+    component: () => import('@/pages/explorer/curate/sdd/SddForm.vue'),
+    meta: { requiresAuth: true }
   },
   {
     path: 'chart',

--- a/app/tests/unit/pages/explorer/SddForm.spec.js
+++ b/app/tests/unit/pages/explorer/SddForm.spec.js
@@ -1,0 +1,33 @@
+import createWrapper from '../../../jest/script/wrapper'
+import { enableAutoDestroy } from '@vue/test-utils'
+import SddForm from '@/pages/explorer/curate/sdd/SddForm.vue'
+
+describe('SddForm.vue', () => {
+  let wrapper
+  beforeEach(async () => {
+    wrapper = await createWrapper(SddForm, {
+      stubs: {
+        MdPortal: { template: '<div><slot/></div>' }
+      }
+    }, true)
+  })
+
+  enableAutoDestroy(afterEach)
+
+  it('renders steppers', () => {
+    expect.assertions(1)
+    const steppers = wrapper.findAll('.md-stepper')
+    expect(steppers.length).toBe(3)
+  })
+
+  it('provides field input for doi', () => {
+    const fields = wrapper.findAll('.md-field')
+    expect(fields.at(0).text()).toContain('DOI')
+  })
+
+  it('contains input areas for spreadsheet and supplementary files', () => {
+    expect.assertions(1)
+    const fileDrop = wrapper.findAll('.form__file-input')
+    expect(fileDrop.length).toBe(2)
+  })
+})

--- a/nginx/default.conf
+++ b/nginx/default.conf
@@ -39,6 +39,7 @@ server {
 
   location /api {
     rewrite /api/(.*) /$1 break;
+    client_max_body_size 1G;
     proxy_pass http://api;
     proxy_read_timeout 1500;
     proxy_connect_timeout 1500;


### PR DESCRIPTION
This addresses multiple technical debt issues that were identified with the SDD upload form
- Files with spaces in the name get ignored, so the file select tool now replaces spaces with underscore
- Add auth requirement to SDD form route
- Add a few basic unit tests
- Increase max file size to account for 500MB metamaterial csv files