### PR TITLE
feat(#443): create QR code landing page

### DIFF
--- a/app/src/assets/css/modules/_misc.scss
+++ b/app/src/assets/css/modules/_misc.scss
@@ -48,6 +48,34 @@
                 list-style: none;
             }
         }
+        &-ordered {
+          margin: 0px -0.8rem !important;
+          @include respond(laptop){
+            margin: 0px -1.3rem !important;
+          }
+          @include respond(tab-port){
+            margin: 0px -1.5rem !important;
+          }
+          @include respond(phone){
+            margin: 0px -1.3rem !important;
+          }
+          ol li {
+            counter-increment: OrderedList;
+            list-style: none;
+            margin: 2rem 1rem;
+            font-size: 1.6rem;
+            line-height: 1.5;
+            @include respond(tab-port){
+              margin: 2rem 1.4rem;
+            }
+            @include respond(phone){
+              font-size: 1.1rem;
+            }
+          }
+          ol li:before {
+            content: "[" counter(OrderedList) "]  ";
+          }
+        }
     }
 
     &_container {

--- a/app/src/assets/css/modules/_utility.scss
+++ b/app/src/assets/css/modules/_utility.scss
@@ -108,6 +108,9 @@
         }
         &-neg {
             margin-top: -1rem !important;
+            &lg {
+              margin-top: -6rem !important
+            }
             &-left {
                 margin-left: -1rem !important;
             }

--- a/app/src/components/nanomine/PageHeader.vue
+++ b/app/src/components/nanomine/PageHeader.vue
@@ -92,10 +92,10 @@
                         </li>
                         <li class="u_margin-right-small">
                             <div class="nav_menu--container">
-                                <a class="u--default-size nav_menu--handler" href="#">MRS2022</a>
+                                <a class="u--default-size nav_menu--handler" href="#">Conferences</a>
                                 <div class="nav_menu--siblings">
-                                    <a href="https://www.mrs.org/meetings-events/spring-meetings-exhibits/2022-mrs-spring-meeting/symposium-sessions/tutorial-sessions-detail/2022_mrs_spring_meeting/sf04/tutorial-sf04-leveraging-data-resources-for-functional" class="nav_menu--siblings-lists"><a>Tutorial Details</a></a>
-                                    <a href="https://bit.ly/NMTUTORIAL" class="nav_menu--siblings-lists"><a>Tutorial Handout</a></a>
+                                  <router-link to="/nm/mrs2022" class="nav_menu--siblings-lists"><a>MRS 2022</a></router-link>
+                                  <router-link to="/nm/cssi2023" class="nav_menu--siblings-lists"><a>CSSI 2023</a></router-link>
                                 </div>
                             </div>
                         </li>

--- a/app/src/pages/nanomine/conferences/CSSI2023.vue
+++ b/app/src/pages/nanomine/conferences/CSSI2023.vue
@@ -1,0 +1,152 @@
+<template>
+  <div class="section_teams">
+    <div class="wrapper u--margin-neglg">
+      <div>
+        <h1 class="visualize_header-h1">
+          Nanocomposites to Metamaterials: A Knowledge Graph Framework
+        </h1>
+      </div>
+      <a class="u--color-primary" target="_blank" href="https://www.cssi-pi2023.org/">
+        <div class="teams_text teams_header">
+          2023 NSF Cyberinfrastructure for Sustained Scientific Innovation Principal Investigator Meeting
+        </div>
+        <div class="teams_text teams_header">
+          September 26-27, 2023
+        </div>
+        <div class="teams_text">
+          Houston, Texas
+        </div>
+      </a>
+
+      <div class="howto_item-header teams_text teams_header">
+        <a>Virtual Poster Link</a>
+      </div>
+      <div class="howto_item-header teams_text">
+        <a href="https://metamaterials.northwestern.edu/" target="_blank">
+          Metamaterial Visualization Tool</a> &ndash; coming soon to MaterialsMine
+      </div>
+      <accordion :startOpen="true" :customTitle="true" title="Referenced Publications:"
+        class="teams_list-ordered">
+        <template #custom_title>
+          <h2 class="teams_text teams_header">Referenced Publications:</h2>
+        </template>
+        <div>
+          <ol>
+            <li v-for="(pub, index) in publications" :key="`pub_${index}`">
+              {{ pub.citation }}
+              <span v-if="pub.doi">
+                DOI: <a :href="`https://www.doi.org/${pub.doi}`" target="_blank">{{ pub.doi }}</a>
+              </span>
+            </li>
+          </ol>
+        </div>
+      </accordion>
+    </div>
+  </div>
+</template>
+
+<script>
+import accordion from '@/components/accordion.vue'
+
+export default {
+  name: 'CSSI2023',
+  components: {
+    accordion
+  },
+  data () {
+    return {
+      publications: [
+        {
+          citation: `B. Ma, N. J. Finan, D. Jany, M. E. Deagen, L. S. Schadler, and L. C. Brinson, “Machine-Learning-Assisted 
+            Understanding of Polymer Nanocomposites Composition–Property Relationship: A Case Study of NanoMine Database,” 
+            Macromolecules, vol. 56, no. 11, pp. 3945–3953, Jun. 2023.`,
+          doi: '10.1021/acs.macromol.2c02249'
+        },
+        {
+          citation: `Lee, Doksoo, Yu-Chin Chan, Wei Chen, Liwei Wang, Anton van Beek, and Wei Chen.
+            "T-METASET: Task-aware acquisition of metamaterial datasets through diversity-based active learning." 
+            Journal of Mechanical Design 145, no. 3 (2023): 031704. `,
+          doi: '10.1115/1.4055925'
+        },
+        {
+          citation: `Chen, Wei, Doksoo Lee, Oluwaseyi Balogun, and Wei Chen. "GAN-DUF: Hierarchical 
+            Deep Generative Models for Design Under Free-Form Geometric Uncertainty." 
+            Journal of Mechanical Design 145, no. 1 (2023): 011703. `,
+          doi: '10.1115/1.4055898'
+        },
+        {
+          citation: `Tanriover, Ibrahim, Doksoo Lee, Wei Chen, and Koray Aydin. "Deep Generative 
+            Modeling and Inverse Design of Manufacturable Free-Form Dielectric Metasurfaces." 
+            ACS Photonics 10, no. 4 (2022): 875-883. `,
+          doi: '10.1021/acsphotonics.2c01006'
+        },
+        {
+          citation: `Wang, Liwei, Zhao Liu, Daicong Da, Yu-Chin Chan, Wei Chen, and Ping Zhu. "Generalized 
+            de-homogenization via sawtooth-function-based mapping and its demonstration on data-driven frequency response optimization." 
+            Computer Methods in Applied Mechanics and Engineering 395 (2022): 114967. `,
+          doi: '10.1016/j.cma.2022.114967'
+        },
+        {
+          citation: `Chen, Wei, Akshay Iyer, and Ramin Bostanabad. "Data centric design: A new approach 
+            to design of microstructural material systems." Engineering 10 (2022): 89-98. `,
+          doi: '10.1016/j.eng.2021.05.022'
+        },
+        {
+          citation: `Chen, Wei, Doksoo Lee, Oluwaseyi Balogun, and Wei Chen. "Hierarchical Deep Generative 
+            Models for Design Under Free-Form Geometric Uncertainty." In International Design Engineering 
+            Technical Conferences and Computers and Information in Engineering Conference, vol. 86236, p. V03BT03A042. 
+            American Society of Mechanical Engineers, 2022. `,
+          doi: '10.1115/DETC2022-89707'
+        },
+        {
+          citation: `Lee, Doksoo, Yu-Chin Chan, Wei Chen, Liwei Wang, and Wei Chen. "T-METASET: Task-Aware 
+            Generation of Metamaterial Datasets by Diversity-Based Active Learning." In International Design 
+            Engineering Technical Conferences and Computers and Information in Engineering Conference, vol. 86229, 
+            p. V03AT03A011. American Society of Mechanical Engineers, 2022. `,
+          doi: '10.1115/DETC2022-87653'
+        },
+        {
+          citation: `Jablonka, Kevin Maik et al. “14 Examples of How LLMs Can Transform Materials Science and Chemistry: 
+          A Reflection on a Large Language Model Hackathon.” Digital Discovery, 2023.`,
+          doi: '10.48550/arXiv.2306.06283'
+        },
+        {
+          citation: `J. Boddapati, M. Flaschel, S. Kumar, L. De Lorenzis and C. Daraio, 2023. Single-test evaluation of 
+            directional elastic properties of anisotropic structured materials. arXiv preprint arXiv:2304.09112. `,
+          doi: '10.48550/arXiv.2304.09112'
+        },
+        {
+          citation: `B. Feng, A. Ogren, C. Daraio and K. Bouman, "Visual Vibration Tomography: Estimating Interior 
+            Material Properties from Monocular Video," in 2022 IEEE/CVF Conference on Computer Vision and Pattern 
+            Recognition (CVPR), New Orleans, LA, USA, 2022 pp. 16210-16219. `,
+          doi: '10.1109/CVPR52688.2022.01575'
+        },
+        {
+          citation: `Z Chen, A Ogren, Chiara Daraio, LC Brinson, C Rudin, How to See Hidden Patterns in Metamaterials 
+            with Interpretable Machine Learning, Extreme Mechanics Letters, accepted 2022. `,
+          doi: '10.1016/j.eml.2022.101895'
+        },
+        {
+          citation: `M.E. Deagen, L.C. Brinson, R.A. Vaia, L.S. Schadler, The Materials Tetrahedron Has a Digital 
+            Twin, MRS Bulletin 47, 379–388 (2022). `,
+          doi: '10.1557/s43577-021-00214-0'
+        },
+        {
+          citation: `X. Li, B. Ma, J. Dai, C. Sui, D. Pande, D. R. Smith, L. C. Brinson, P.-C. Hsu, Metalized 
+            polyamide heterostructure as a moisture-responsive actuator for multimodal adaptive personal 
+            heat management, Science Advances 7, eabj7906 (2021). `,
+          doi: '10.1126/sciadv.abj7906'
+        },
+        {
+          citation: `Lee, D., Jiang, S., Balogun, O., & Chen, W., "Dynamic Control of Plasmonic Localization 
+            by Inverse Optimization of Spatial Phase Modulation", ACS Photonics, 2022 9 (2), 351-359. `,
+          doi: '10.1021/acsphotonics.1c01043'
+        }
+      ]
+    }
+  },
+  created () {
+    this.$store.commit('setAppHeaderInfo', { icon: 'co_present', name: 'CSSI PI Meeting 2023' })
+  }
+}
+</script>

--- a/app/src/pages/nanomine/conferences/MRS2022.vue
+++ b/app/src/pages/nanomine/conferences/MRS2022.vue
@@ -1,0 +1,40 @@
+<template>
+  <div class="section_teams">
+    <div class="wrapper u--margin-neglg">
+      <div>
+        <h1 class="visualize_header-h1">
+          Leveraging Data Resources for Functional Polymers and
+          Polymer Nanocomposite Research—Principles and Examples
+        </h1>
+      </div>
+      <div class="howto_item-header teams_text teams_header">
+        <a href="https://www.mrs.org/meetings-events/spring-meetings-exhibits/2022-mrs-spring-meeting/symposium-sessions/tutorial-sessions-detail/2022_mrs_spring_meeting/sf04/tutorial-sf04-leveraging-data-resources-for-functional"
+          target="_blank">Tutorial details</a>
+      </div>
+      <div class="howto_item-header teams_text">
+        <a href="https://bit.ly/NMTUTORIAL" target="_blank">Tutorial handout</a>
+      </div>
+      <a class="u--color-primary" target="_blank"
+        href="https://www.mrs.org/meetings-events/spring-meetings-exhibits/past-spring-meetings/2022-mrs-spring-meeting">
+        <div class="teams_text teams_header">
+          2022 Materials Research Society Spring Meeting & Exhibit
+        </div>
+        <div class="teams_text teams_header">
+          Sunday, May 8, 2022
+        </div>
+        <div class="teams_text">
+          Honolulu, Hawaii
+        </div>
+      </a>
+    </div>
+  </div>
+</template>
+
+<script>
+export default {
+  name: 'MRS2022',
+  created () {
+    this.$store.commit('setAppHeaderInfo', { icon: 'co_present', name: 'MRS Conference 2022' })
+  }
+}
+</script>

--- a/app/src/router/module/nanomine.js
+++ b/app/src/router/module/nanomine.js
@@ -70,6 +70,24 @@ const nanomineRoutes = [
         /* webpackChunkName: "contactus" */ '@/pages/nanomine/contactus/ContactUs.vue'
       ),
     meta: { requiresAuth: false }
+  },
+  {
+    path: 'mrs2022',
+    name: 'MRS2022',
+    component: () =>
+      import(
+        /* webpackChunkName: "mrs2022" */ '@/pages/nanomine/conferences/MRS2022.vue'
+      ),
+    meta: { requiresAuth: false }
+  },
+  {
+    path: 'cssi2023',
+    name: 'CSSI2023',
+    component: () =>
+      import(
+        /* webpackChunkName: "cssi2023" */ '@/pages/nanomine/conferences/CSSI2023.vue'
+      ),
+    meta: { requiresAuth: false }
   }
 ]
 


### PR DESCRIPTION
This task creates a landing page for the QR code that will go on the poster for the CSSI PI meeting. 
It also replaces the old "MRS2022" tab with a new "Conferences" tab. The links that were previously in the old tab are now on a separate MRS 2022 page.

Both new conference pages (MRS 2022, CSSI 2023) contain relevant links for the conference materials. The CSSI 2023 page lists all publications (along with their DOI links) from the annual report. 

NOTE: as of opening this PR, I haven't yet added a virtual poster link, so that will need to be updated whenever it's available

closes #443 