### PR TITLE
feat(#445): Update virtual poster link

### DIFF
--- a/app/src/pages/nanomine/conferences/CSSI2023.vue
+++ b/app/src/pages/nanomine/conferences/CSSI2023.vue
@@ -19,7 +19,7 @@
       </a>
 
       <div class="howto_item-header teams_text teams_header">
-        <a>Virtual Poster Link</a>
+        <a href="https://doi.org/10.6084/m9.figshare.24201960.v1" target="_blank">Virtual Poster Link</a>
       </div>
       <div class="howto_item-header teams_text">
         <a href="https://metamaterials.northwestern.edu/" target="_blank">

--- a/app/tests/unit/pages/nanomine/conferences/cssi2023.spec.js
+++ b/app/tests/unit/pages/nanomine/conferences/cssi2023.spec.js
@@ -14,11 +14,9 @@ describe('CSSI2023.vue', () => {
   it('provides links to relevant resources', () => {
     const links = wrapper.findAll('a')
     expect(links.length).toBeGreaterThan(3)
-    const conferenceLink = links.at(0)
-    // const posterLink = links.at(1) // Update when link is provided
-    const metamaterialViz = links.at(2) // Update when visualization is integrated
-    expect(conferenceLink.attributes('href')).toBe('https://www.cssi-pi2023.org/')
-    expect(metamaterialViz.attributes('href')).toBe('https://metamaterials.northwestern.edu/')
+    expect(links.at(0).attributes('href')).toBe('https://www.cssi-pi2023.org/')
+    expect(links.at(1).attributes('href')).toBe('https://doi.org/10.6084/m9.figshare.24201960.v1')
+    expect(links.at(2).attributes('href')).toBe('https://metamaterials.northwestern.edu/') // Update when visualization is integrated
   })
 
   it('provides a full list of publications', () => {


### PR DESCRIPTION
We previously didn't have a [link to the CSSI PI meeting virtual poster]( https://doi.org/10.6084/m9.figshare.24201960.v1) on the QR code landing page. This ticket updates the link (and relevant unit tests)

closes #445 